### PR TITLE
Remove created requirement for updates, keep for posts

### DIFF
--- a/src/main/java/eu/dissco/annotationprocessingservice/component/SchemaValidatorComponent.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/component/SchemaValidatorComponent.java
@@ -29,6 +29,10 @@ public class SchemaValidatorComponent {
     validateId(annotation, doNotIncludeId);
     var annotationRequest = mapper.valueToTree(annotation);
     var errors = annotationSchema.validate(annotationRequest);
+    if (Boolean.TRUE.equals(doNotIncludeId) && annotation.getDcTermsCreated() == null){
+      log.error("Invalid annotation received. Missing dcterms created");
+      throw new AnnotationValidationException();
+    }
     if (errors.isEmpty()) {
       return;
     }

--- a/src/main/java/eu/dissco/annotationprocessingservice/component/SchemaValidatorComponent.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/component/SchemaValidatorComponent.java
@@ -24,12 +24,12 @@ public class SchemaValidatorComponent {
   }
 
 
-  public void validateAnnotationRequest(Annotation annotation, boolean doNotIncludeId)
+  public void validateAnnotationRequest(Annotation annotation, boolean isNewAnnotation)
       throws AnnotationValidationException {
-    validateId(annotation, doNotIncludeId);
+    validateId(annotation, isNewAnnotation);
     var annotationRequest = mapper.valueToTree(annotation);
     var errors = annotationSchema.validate(annotationRequest);
-    if (Boolean.TRUE.equals(doNotIncludeId) && annotation.getDcTermsCreated() == null){
+    if (Boolean.TRUE.equals(isNewAnnotation) && annotation.getDcTermsCreated() == null){
       log.error("Invalid annotation received. Missing dcterms created");
       throw new AnnotationValidationException();
     }
@@ -40,13 +40,13 @@ public class SchemaValidatorComponent {
     throw new AnnotationValidationException();
   }
 
-  private void validateId(Annotation annotation, Boolean doNotIncludeId)
+  private void validateId(Annotation annotation, Boolean isNewAnnotation)
       throws AnnotationValidationException {
-    if (Boolean.TRUE.equals(doNotIncludeId) && annotation.getOdsId() != null) {
+    if (Boolean.TRUE.equals(isNewAnnotation) && annotation.getOdsId() != null) {
       log.error( "Attempting overwrite annotation with \"ods:id\" " + annotation.getOdsId());
       throw new AnnotationValidationException();
     }
-    if (Boolean.FALSE.equals(doNotIncludeId) && annotation.getOdsId() == null) {
+    if (Boolean.FALSE.equals(isNewAnnotation) && annotation.getOdsId() == null) {
       log.error("\"ods:id\" not provided for annotation update");
       throw new AnnotationValidationException();
     }

--- a/src/main/resources/json-schema/annotation_request.json
+++ b/src/main/resources/json-schema/annotation_request.json
@@ -185,8 +185,7 @@
     "oa:motivation",
     "oa:target",
     "oa:body",
-    "oa:creator",
-    "dcterms:created"
+    "oa:creator"
   ],
   "additionalProperties": false
 }

--- a/src/test/java/eu/dissco/annotationprocessingservice/component/SchemaValidatorComponentTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/component/SchemaValidatorComponentTest.java
@@ -78,6 +78,17 @@ class SchemaValidatorComponentTest {
             false));
   }
 
+  @Test
+  void testCreateMissingCreated() {
+    // Given
+    var annotationRequest = givenAnnotationRequest().withDcTermsCreated(null);
+
+    // Then
+    assertThrows(AnnotationValidationException.class,
+        () -> schemaValidator.validateAnnotationRequest(annotationRequest,
+            false));
+  }
+
   @ParameterizedTest
   @MethodSource("validAnnotations")
   void testValidAnnotation(Annotation annotationRequest, Boolean isNew) {


### PR DESCRIPTION
For creating new annotations, we need dcterms:created.
If it is an update, the processing service uses the existing field.

I think we want two different json schemas, one for updates and one for posts. Will address that when I make the opends schema repo