### PR TITLE
Feature/annotation as builder

### DIFF
--- a/src/main/java/eu/dissco/annotationprocessingservice/component/JsonPathComponent.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/component/JsonPathComponent.java
@@ -1,5 +1,9 @@
 package eu.dissco.annotationprocessingservice.component;
 
+import static com.jayway.jsonpath.Criteria.where;
+import static com.jayway.jsonpath.Filter.filter;
+import static com.jayway.jsonpath.JsonPath.using;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -21,10 +25,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.springframework.stereotype.Component;
-
-import static com.jayway.jsonpath.Criteria.where;
-import static com.jayway.jsonpath.Filter.filter;
-import static com.jayway.jsonpath.JsonPath.using;
 
 @Component
 @RequiredArgsConstructor
@@ -71,10 +71,11 @@ public class JsonPathComponent {
         newSelector = new FieldSelector()
             .withOdsField(append+targetPath);
       }
-      newTargets.add(new Target()
-          .withOdsType(baseTarget.getOdsType())
-          .withOdsId("https://doi.org/" + newTargetId)
-          .withSelector(newSelector));
+      newTargets.add(Target.builder()
+          .odsType(baseTarget.getOdsType())
+          .odsId("https://doi.org/" + newTargetId)
+          .oaSelector(newSelector)
+          .build());
     }
     return newTargets;
   }

--- a/src/main/java/eu/dissco/annotationprocessingservice/domain/annotation/AggregateRating.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/domain/annotation/AggregateRating.java
@@ -1,40 +1,17 @@
 package eu.dissco.annotationprocessingservice.domain.annotation;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.Builder;
+import lombok.Value;
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@EqualsAndHashCode
-@ToString
+@Value
+@Builder
 public class AggregateRating {
 
   @JsonProperty("ods:type")
-  private String odsType;
+  String odsType;
   @JsonProperty("schema.org:ratingCount")
-  private double ratingCount;
+  double ratingCount;
   @JsonProperty("schema.org:ratingValue")
-  private double ratingValue;
-
-  public AggregateRating withOdsType(String odsType) {
-    this.odsType = odsType;
-    return this;
-  }
-
-  public AggregateRating withRatingCount(double ratingCount) {
-    this.ratingCount = ratingCount;
-    return this;
-  }
-
-  public AggregateRating withRatingValue(double ratingValue) {
-    this.ratingValue = ratingValue;
-    return this;
-  }
-
-
+  double ratingValue;
 }

--- a/src/main/java/eu/dissco/annotationprocessingservice/domain/annotation/Annotation.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/domain/annotation/Annotation.java
@@ -2,17 +2,13 @@ package eu.dissco.annotationprocessingservice.domain.annotation;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Instant;
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.Builder;
+import lombok.Data;
+import lombok.experimental.Accessors;
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@EqualsAndHashCode
-@ToString
+@Data
+@Accessors(chain = true)
+@Builder
 public class Annotation {
 
   @JsonProperty("ods:id")
@@ -22,6 +18,7 @@ public class Annotation {
   @JsonProperty("ods:version")
   private Integer odsVersion;
   @JsonProperty("rdf:type")
+  @Builder.Default
   private String rdfType = "Annotation";
   @JsonProperty("oa:motivation")
   private Motivation oaMotivation;
@@ -45,82 +42,5 @@ public class Annotation {
   private AggregateRating odsAggregateRating;
   @JsonProperty("placeInBatch")
   private Integer placeInBatch;
-
-  public Annotation withOdsId(String odsId) {
-    this.odsId = odsId;
-    return this;
-  }
-
-  public Annotation withOdsJobId(String odsJobId) {
-    this.odsJobId = odsJobId;
-    return this;
-  }
-
-  public Annotation withOdsVersion(int odsVersion) {
-    this.odsVersion = odsVersion;
-    return this;
-  }
-
-  public Annotation withRdfType(String rdfType) {
-    this.rdfType = rdfType;
-    return this;
-  }
-
-  public Annotation withOaMotivation(Motivation oaMotivation) {
-    this.oaMotivation = oaMotivation;
-    return this;
-  }
-
-  public Annotation withOaMotivatedBy(String oaMotivatedBy) {
-    this.oaMotivatedBy = oaMotivatedBy;
-    return this;
-  }
-
-  public Annotation withOaTarget(Target oaTarget) {
-    this.oaTarget = oaTarget;
-    return this;
-  }
-
-  public Annotation withOaBody(Body oaBody) {
-    this.oaBody = oaBody;
-    return this;
-  }
-
-  public Annotation withOaCreator(Creator oaCreator) {
-    this.oaCreator = oaCreator;
-    return this;
-  }
-
-  public Annotation withDcTermsCreated(Instant dcTermsCreated) {
-    this.dcTermsCreated = dcTermsCreated;
-    return this;
-  }
-
-  public Annotation withOdsDeletedOn(Instant odsDeletedOn) {
-    this.odsDeletedOn = odsDeletedOn;
-    return this;
-  }
-
-  public Annotation withAsGenerator(Generator asGenerator) {
-    this.asGenerator = asGenerator;
-    return this;
-  }
-
-
-  public Annotation withOaGenerated(Instant oaGenerated) {
-    this.oaGenerated = oaGenerated;
-    return this;
-  }
-
-  public Annotation withOdsAggregateRating(AggregateRating odsAggregateRating) {
-    this.odsAggregateRating = odsAggregateRating;
-    return this;
-  }
-
-  public Annotation withPlaceInBatch(Integer placeInBatch){
-    this.placeInBatch = placeInBatch;
-    return this;
-  }
-
 
 }

--- a/src/main/java/eu/dissco/annotationprocessingservice/domain/annotation/Body.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/domain/annotation/Body.java
@@ -2,46 +2,20 @@ package eu.dissco.annotationprocessingservice.domain.annotation;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.Builder;
+import lombok.Value;
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@EqualsAndHashCode
-@ToString
+@Value
+@Builder
 public class Body {
 
   @JsonProperty("ods:type")
-  private String odsType;
+  String odsType;
   @JsonProperty("oa:value")
-  private List<String> oaValue;
+  List<String> oaValue;
   @JsonProperty("dcterms:reference")
-  private String dcTermsReference;
+  String dcTermsReference;
   @JsonProperty("ods:score")
-  private double odsScore;
-
-  public Body withOdsType(String odsType) {
-    this.odsType = odsType;
-    return this;
-  }
-
-  public Body withOaValue(List<String> oaValue) {
-    this.oaValue = oaValue;
-    return this;
-  }
-
-  public Body withDcTermsReference(String dcTermsReference) {
-    this.dcTermsReference = dcTermsReference;
-    return this;
-  }
-
-  public Body withOdsScore(double odsScore) {
-    this.odsScore = odsScore;
-    return this;
-  }
+  double odsScore;
 
 }

--- a/src/main/java/eu/dissco/annotationprocessingservice/domain/annotation/Creator.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/domain/annotation/Creator.java
@@ -1,39 +1,17 @@
 package eu.dissco.annotationprocessingservice.domain.annotation;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.Builder;
+import lombok.Value;
 
-@NoArgsConstructor
-@AllArgsConstructor
-@Getter
-@EqualsAndHashCode
-@ToString
+@Value
+@Builder
 public class Creator {
-
   @JsonProperty("ods:type")
-  private String odsType;
+  String odsType;
   @JsonProperty("foaf:name")
-  private String foafName;
+  String foafName;
   @JsonProperty("ods:id")
-  private String odsId;
-
-  public Creator withOdsType(String odsType) {
-    this.odsType = odsType;
-    return this;
-  }
-
-  public Creator withFoafName(String foafName) {
-    this.foafName = foafName;
-    return this;
-  }
-
-  public Creator withOdsId(String odsId) {
-    this.odsId = odsId;
-    return this;
-  }
+  String odsId;
 
 }

--- a/src/main/java/eu/dissco/annotationprocessingservice/domain/annotation/Generator.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/domain/annotation/Generator.java
@@ -1,40 +1,17 @@
 package eu.dissco.annotationprocessingservice.domain.annotation;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.Builder;
+import lombok.Value;
 
-@NoArgsConstructor
-@AllArgsConstructor
-@Getter
-@EqualsAndHashCode
-@ToString
+@Value
+@Builder
 public class Generator {
-
   @JsonProperty("ods:type")
-  private String odsType;
+  String odsType;
   @JsonProperty("foaf:name")
-  private String foafName;
+  String foafName;
   @JsonProperty("ods:id")
-  private String odsId;
-
-  public Generator withOdsType(String odsType) {
-    this.odsType = odsType;
-    return this;
-  }
-
-  public Generator withFoafName(String foafName) {
-    this.foafName = foafName;
-    return this;
-  }
-
-  public Generator withOdsId(String odsId) {
-    this.odsId = odsId;
-    return this;
-  }
-
+  String odsId;
 
 }

--- a/src/main/java/eu/dissco/annotationprocessingservice/domain/annotation/HasRoi.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/domain/annotation/HasRoi.java
@@ -1,46 +1,19 @@
 package eu.dissco.annotationprocessingservice.domain.annotation;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.Builder;
+import lombok.Value;
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@EqualsAndHashCode
-@ToString
+@Value
+@Builder
 public class HasRoi {
-
   @JsonProperty("ac:xFrac")
-  private double valX;
+  double valX;
   @JsonProperty("ac:yFrac")
-  private double valY;
+  double valY;
   @JsonProperty("ac:widthFrac")
-  private double widthFrac;
+  double widthFrac;
   @JsonProperty("ac:heightFrac")
-  private double heightFrac;
-
-  public HasRoi withAcXFrac(double valX) {
-    this.valX = valX;
-    return this;
-  }
-
-  public HasRoi withAcYFrac(double valY) {
-    this.valY = valY;
-    return this;
-  }
-
-  public HasRoi withAcWidthFrac(double widthFrac) {
-    this.widthFrac = widthFrac;
-    return this;
-  }
-
-  public HasRoi withAcHeightFrac(double heightFrac) {
-    this.heightFrac = heightFrac;
-    return this;
-  }
+  double heightFrac;
 
 }

--- a/src/main/java/eu/dissco/annotationprocessingservice/domain/annotation/Target.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/domain/annotation/Target.java
@@ -1,40 +1,16 @@
 package eu.dissco.annotationprocessingservice.domain.annotation;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.Builder;
+import lombok.Value;
 
-@NoArgsConstructor
-@AllArgsConstructor
-@Getter
-@EqualsAndHashCode
-@ToString
+@Value
+@Builder
 public class Target {
-
   @JsonProperty("ods:id")
-  private String odsId;
+  String odsId;
   @JsonProperty("ods:type")
-  private AnnotationTargetType odsType;
+  AnnotationTargetType odsType;
   @JsonProperty("oa:selector")
-  private Selector oaSelector;
-
-  public Target withOdsId(String odsId) {
-    this.odsId = odsId;
-    return this;
-  }
-
-  public Target withOdsType(AnnotationTargetType odsType) {
-    this.odsType = odsType;
-    return this;
-  }
-
-  public Target withSelector(Selector oaSelector) {
-    this.oaSelector = oaSelector;
-    return this;
-  }
-
-
+  Selector oaSelector;
 }

--- a/src/main/java/eu/dissco/annotationprocessingservice/repository/AnnotationRepository.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/repository/AnnotationRepository.java
@@ -59,23 +59,24 @@ public class AnnotationRepository {
 
   private Annotation mapAnnotation(Record dbRecord) {
     try {
-      return new Annotation()
-          .withOdsId(dbRecord.get(ANNOTATION.ID))
-          .withRdfType(dbRecord.get(ANNOTATION.TYPE))
-          .withOdsVersion(dbRecord.get(ANNOTATION.VERSION))
-          .withOaMotivation(Motivation.fromString(dbRecord.get(ANNOTATION.MOTIVATION)))
-          .withOaMotivatedBy(dbRecord.get(ANNOTATION.MOTIVATED_BY))
-          .withOaTarget(mapper.readValue(dbRecord.get(ANNOTATION.TARGET).data(), Target.class))
-          .withOaBody(mapper.readValue(dbRecord.get(ANNOTATION.BODY).data(), Body.class))
-          .withOaCreator(mapper.readValue(dbRecord.get(ANNOTATION.CREATOR).data(), Creator.class))
-          .withDcTermsCreated(dbRecord.get(ANNOTATION.CREATED))
-          .withOdsDeletedOn(dbRecord.get(ANNOTATION.DELETED_ON))
-          .withAsGenerator(
+      return Annotation.builder()
+          .odsId(dbRecord.get(ANNOTATION.ID))
+          .rdfType(dbRecord.get(ANNOTATION.TYPE))
+          .odsVersion(dbRecord.get(ANNOTATION.VERSION))
+          .oaMotivation(Motivation.fromString(dbRecord.get(ANNOTATION.MOTIVATION)))
+          .oaMotivatedBy(dbRecord.get(ANNOTATION.MOTIVATED_BY))
+          .oaTarget(mapper.readValue(dbRecord.get(ANNOTATION.TARGET).data(), Target.class))
+          .oaBody(mapper.readValue(dbRecord.get(ANNOTATION.BODY).data(), Body.class))
+          .oaCreator(mapper.readValue(dbRecord.get(ANNOTATION.CREATOR).data(), Creator.class))
+          .dcTermsCreated(dbRecord.get(ANNOTATION.CREATED))
+          .odsDeletedOn(dbRecord.get(ANNOTATION.DELETED_ON))
+          .asGenerator(
               mapper.readValue(dbRecord.get(ANNOTATION.GENERATOR).data(), Generator.class))
-          .withOaGenerated(dbRecord.get(ANNOTATION.GENERATED))
-          .withOdsAggregateRating(mapper.readValue(dbRecord.get(ANNOTATION.AGGREGATE_RATING).data(),
+          .oaGenerated(dbRecord.get(ANNOTATION.GENERATED))
+          .odsAggregateRating(mapper.readValue(dbRecord.get(ANNOTATION.AGGREGATE_RATING).data(),
               AggregateRating.class))
-          .withOdsJobId(dbRecord.get(ANNOTATION.MJR_JOB_ID));
+          .odsJobId(dbRecord.get(ANNOTATION.MJR_JOB_ID))
+          .build();
     } catch (JsonProcessingException e) {
       log.error("Failed to get data from database, Unable to parse JSONB to JSON", e);
       throw new DataBaseException(e.getMessage());

--- a/src/main/java/eu/dissco/annotationprocessingservice/service/AbstractProcessingService.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/service/AbstractProcessingService.java
@@ -45,10 +45,11 @@ public abstract class AbstractProcessingService {
   }
 
   private Generator createGenerator() {
-    return new Generator()
-        .withOdsId(applicationProperties.getProcessorHandle())
-        .withFoafName("Annotation Processing Service")
-        .withOdsType("oa:SoftwareAgent");
+    return Generator.builder()
+        .odsId(applicationProperties.getProcessorHandle())
+        .foafName("Annotation Processing Service")
+        .odsType("oa:SoftwareAgent")
+        .build();
   }
 
   protected void enrichUpdateAnnotation(Annotation annotation, Annotation currentAnnotation) {

--- a/src/main/java/eu/dissco/annotationprocessingservice/service/AbstractProcessingService.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/service/AbstractProcessingService.java
@@ -33,16 +33,15 @@ public abstract class AbstractProcessingService {
   protected final BatchAnnotationService batchAnnotationService;
 
   protected void enrichNewAnnotation(Annotation annotation, String id) {
-    annotation
-        .withOdsId(id)
-        .withOdsVersion(1)
-        .withAsGenerator(createGenerator())
-        .withOaGenerated(Instant.now());
+    annotation.setOdsId(id)
+        .setOdsVersion(1)
+        .setAsGenerator(createGenerator())
+        .setOaGenerated(Instant.now());
   }
 
   protected void enrichNewAnnotation(Annotation annotation, String id, String jobId) {
     enrichNewAnnotation(annotation, id);
-    annotation.withOdsJobId(applicationProperties.getHandleProxy() + jobId);
+    annotation.setOdsJobId(applicationProperties.getHandleProxy() + jobId);
   }
 
   private Generator createGenerator() {
@@ -53,19 +52,18 @@ public abstract class AbstractProcessingService {
   }
 
   protected void enrichUpdateAnnotation(Annotation annotation, Annotation currentAnnotation) {
-    annotation
-        .withOdsId(currentAnnotation.getOdsId())
-        .withOdsVersion(currentAnnotation.getOdsVersion() + 1)
-        .withOaGenerated(currentAnnotation.getOaGenerated())
-        .withAsGenerator(currentAnnotation.getAsGenerator())
-        .withOaCreator(currentAnnotation.getOaCreator())
-        .withDcTermsCreated(currentAnnotation.getDcTermsCreated());
+    annotation.setOdsId(currentAnnotation.getOdsId())
+        .setOdsVersion(currentAnnotation.getOdsVersion() + 1)
+        .setOaGenerated(currentAnnotation.getOaGenerated())
+        .setAsGenerator(currentAnnotation.getAsGenerator())
+        .setOaCreator(currentAnnotation.getOaCreator())
+        .setDcTermsCreated(currentAnnotation.getDcTermsCreated());
   }
 
   protected void enrichUpdateAnnotation(Annotation annotation, Annotation currentAnnotation,
       String jobId) {
     enrichUpdateAnnotation(annotation, currentAnnotation);
-    annotation.withOdsJobId(jobId);
+    annotation.setOdsJobId(jobId);
   }
 
   protected static boolean annotationsAreEqual(Annotation currentAnnotation,

--- a/src/main/java/eu/dissco/annotationprocessingservice/service/BatchAnnotationService.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/service/BatchAnnotationService.java
@@ -107,15 +107,14 @@ public class BatchAnnotationService {
   private List<Annotation> copyAnnotation(Annotation baseAnnotation, List<Target> targets) {
     ArrayList<Annotation> newAnnotations = new ArrayList<>();
     for (var target : targets) {
-      newAnnotations.add(new Annotation()
-          .withOdsId(null)
-          .withOaMotivation(baseAnnotation.getOaMotivation())
-          .withDcTermsCreated(baseAnnotation.getDcTermsCreated())
-          .withOaCreator(baseAnnotation.getOaCreator())
-          .withOaBody(baseAnnotation.getOaBody())
-          .withOdsAggregateRating(baseAnnotation.getOdsAggregateRating())
-          .withOaTarget(target
-          ));
+      newAnnotations.add(Annotation.builder()
+          .odsId(null)
+          .oaMotivation(baseAnnotation.getOaMotivation())
+          .dcTermsCreated(baseAnnotation.getDcTermsCreated())
+          .oaCreator(baseAnnotation.getOaCreator())
+          .oaBody(baseAnnotation.getOaBody())
+          .odsAggregateRating(baseAnnotation.getOdsAggregateRating())
+          .oaTarget(target).build());
     }
     return newAnnotations;
   }

--- a/src/test/java/eu/dissco/annotationprocessingservice/TestUtils.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/TestUtils.java
@@ -18,6 +18,7 @@ import eu.dissco.annotationprocessingservice.domain.annotation.Creator;
 import eu.dissco.annotationprocessingservice.domain.annotation.FieldSelector;
 import eu.dissco.annotationprocessingservice.domain.annotation.Generator;
 import eu.dissco.annotationprocessingservice.domain.annotation.Motivation;
+import eu.dissco.annotationprocessingservice.domain.annotation.Selector;
 import eu.dissco.annotationprocessingservice.domain.annotation.Target;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -115,17 +116,45 @@ public class TestUtils {
   }
 
   public static Body givenOaBody() {
-    return new Body().withOdsType("ods:specimenName")
-        .withOaValue(new ArrayList<>(List.of("a comment")))
-        .withDcTermsReference("https://medialib.naturalis.nl/file/id/ZMA.UROCH.P.1555/format/large")
-        .withOdsScore(0.99);
+    return givenOaBody("a comment");
+  }
+
+  public static Body givenOaBodySetType(String type) {
+    return Body.builder()
+        .odsType(type)
+        .oaValue(new ArrayList<>(List.of("a comment")))
+        .dcTermsReference("https://medialib.naturalis.nl/file/id/ZMA.UROCH.P.1555/format/large")
+        .odsScore(0.99)
+        .build();
+  }
+
+  public static Body givenOaBody(String value) {
+    return Body.builder()
+        .odsType("ods:specimenName")
+        .oaValue(new ArrayList<>(List.of(value)))
+        .dcTermsReference("https://medialib.naturalis.nl/file/id/ZMA.UROCH.P.1555/format/large")
+        .odsScore(0.99)
+        .build();
   }
 
   public static Target givenOaTarget(String targetId) {
-    return new Target()
-        .withOdsId(HANDLE_PROXY + targetId)
-        .withSelector(givenSelector())
-        .withOdsType(AnnotationTargetType.DIGITAL_SPECIMEN);
+    return givenOaTarget(targetId, AnnotationTargetType.DIGITAL_SPECIMEN);
+  }
+
+  public static Target givenOaTarget(String targetId, AnnotationTargetType targetType) {
+    return Target.builder()
+        .odsId(HANDLE_PROXY + targetId)
+        .oaSelector(givenSelector())
+        .odsType(targetType)
+        .build();
+  }
+
+  public static Target givenOaTarget(String targetId, AnnotationTargetType targetType, Selector selector) {
+    return Target.builder()
+        .odsId(HANDLE_PROXY + targetId)
+        .oaSelector(selector)
+        .odsType(targetType)
+        .build();
   }
 
   public static FieldSelector givenSelector() {
@@ -134,17 +163,31 @@ public class TestUtils {
   }
 
   public static Creator givenCreator(String userId) {
-    return new Creator().withFoafName("Test User").withOdsId(userId).withOdsType("ORCID");
+    return Creator.builder()
+        .foafName("Test User")
+        .odsId(userId)
+        .odsType("ORCID")
+        .build();
   }
 
   public static Generator givenGenerator() {
-    return new Generator().withFoafName("Annotation Processing Service")
-        .withOdsId("https://hdl.handle.net/anno-process-service-pid")
-        .withOdsType("oa:SoftwareAgent");
+    return Generator.builder()
+        .foafName("Annotation Processing Service")
+        .odsId("https://hdl.handle.net/anno-process-service-pid")
+        .odsType("oa:SoftwareAgent")
+        .build();
   }
 
   public static AggregateRating givenAggregationRating() {
-    return new AggregateRating().withRatingValue(0.1).withOdsType("Score").withRatingCount(0.2);
+    return givenAggregationRating(0.1);
+  }
+
+  public static AggregateRating givenAggregationRating(double ratingValue) {
+    return AggregateRating.builder()
+        .ratingValue(ratingValue)
+        .odsType("Score")
+        .ratingCount(0.2)
+        .build();
   }
 
 

--- a/src/test/java/eu/dissco/annotationprocessingservice/TestUtils.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/TestUtils.java
@@ -76,35 +76,38 @@ public class TestUtils {
   }
 
   public static Annotation givenAnnotationProcessedWeb(String annotationId, String userId, String targetId){
-    return new Annotation()
-        .withOdsId(annotationId)
-        .withOdsVersion(1)
-        .withOaBody(givenOaBody())
-        .withOaMotivation(Motivation.COMMENTING)
-        .withOaTarget(givenOaTarget(targetId))
-        .withOaCreator(givenCreator(userId))
-        .withDcTermsCreated(CREATED)
-        .withOaGenerated(CREATED)
-        .withAsGenerator(givenGenerator())
-        .withOdsAggregateRating(givenAggregationRating());
+    return Annotation.builder()
+        .odsId(annotationId)
+        .odsVersion(1)
+        .oaBody(givenOaBody())
+        .oaMotivation(Motivation.COMMENTING)
+        .oaTarget(givenOaTarget(targetId))
+        .oaCreator(givenCreator(userId))
+        .dcTermsCreated(CREATED)
+        .oaGenerated(CREATED)
+        .asGenerator(givenGenerator())
+        .odsAggregateRating(givenAggregationRating())
+        .build();
   }
 
   public static Annotation givenAnnotationProcessedAlt() {
-    return givenAnnotationProcessed(ID, CREATOR, TARGET_ID).withOaMotivation(Motivation.EDITING);
+    return givenAnnotationProcessed(ID, CREATOR, TARGET_ID)
+        .setOaMotivation(Motivation.EDITING);
   }
 
   public static Annotation givenAnnotationProcessed(String annotationId, String userId,
       String targetId) {
-    var annotation = givenAnnotationProcessedWeb(annotationId, userId, targetId);
-    return annotation.withOdsJobId(HANDLE_PROXY + JOB_ID);
+    return givenAnnotationProcessedWeb(annotationId, userId, targetId)
+        .setOdsJobId(HANDLE_PROXY + JOB_ID);
   }
 
   public static Annotation givenAnnotationRequest(String targetId) {
-    return new Annotation()
-        .withOaBody(givenOaBody())
-        .withOaMotivation(Motivation.COMMENTING).withOaTarget(givenOaTarget(targetId))
-        .withDcTermsCreated(CREATED).withOaCreator(givenCreator(CREATOR))
-        .withOdsAggregateRating(givenAggregationRating());
+    return Annotation.builder()
+        .oaBody(givenOaBody())
+        .oaMotivation(Motivation.COMMENTING).oaTarget(givenOaTarget(targetId))
+        .dcTermsCreated(CREATED).oaCreator(givenCreator(CREATOR))
+        .odsAggregateRating(givenAggregationRating())
+        .build();
   }
 
   public static Annotation givenAnnotationRequest() {
@@ -286,7 +289,8 @@ public class TestUtils {
   }
 
   public static AnnotationEvent givenAnnotationEventBatchEnabled(){
-    return new AnnotationEvent(List.of(givenAnnotationRequest().withPlaceInBatch(1)), JOB_ID,
+    return new AnnotationEvent(List.of(givenAnnotationRequest()
+        .setPlaceInBatch(1)), JOB_ID,
         List.of(givenBatchMetadataLatitudeSearch()), null);
   }
 

--- a/src/test/java/eu/dissco/annotationprocessingservice/component/AnnotationHasherTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/component/AnnotationHasherTest.java
@@ -52,7 +52,7 @@ class AnnotationHasherTest {
         var expected = UUID.fromString("a831698e-8bfd-4dbe-51c4-3236d0f2b047");
 
         // When
-        var result = annotationHasher.getAnnotationHash(givenAnnotationProcessed().withOaTarget(givenOaTarget(TARGET_ID).withSelector(selector)));
+        var result = annotationHasher.getAnnotationHash(givenAnnotationProcessed().setOaTarget(givenOaTarget(TARGET_ID).withSelector(selector)));
 
         // Then
         assertThat(result).isEqualTo(expected);
@@ -66,7 +66,7 @@ class AnnotationHasherTest {
         var expected = UUID.fromString("753ad133-4212-e03b-00e7-b757957901fd");
 
         // When
-        var result = annotationHasher.getAnnotationHash(givenAnnotationProcessed().withOaTarget(givenOaTarget(TARGET_ID).withSelector(selector)));
+        var result = annotationHasher.getAnnotationHash(givenAnnotationProcessed().setOaTarget(givenOaTarget(TARGET_ID).withSelector(selector)));
 
         // Then
         assertThat(result).isEqualTo(expected);

--- a/src/test/java/eu/dissco/annotationprocessingservice/component/AnnotationHasherTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/component/AnnotationHasherTest.java
@@ -1,14 +1,17 @@
 package eu.dissco.annotationprocessingservice.component;
 
 import static eu.dissco.annotationprocessingservice.TestUtils.ANNOTATION_HASH;
+import static eu.dissco.annotationprocessingservice.TestUtils.HANDLE_PROXY;
 import static eu.dissco.annotationprocessingservice.TestUtils.TARGET_ID;
 import static eu.dissco.annotationprocessingservice.TestUtils.givenAnnotationProcessed;
 import static eu.dissco.annotationprocessingservice.TestUtils.givenOaTarget;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import eu.dissco.annotationprocessingservice.domain.annotation.AnnotationTargetType;
 import eu.dissco.annotationprocessingservice.domain.annotation.ClassSelector;
 import eu.dissco.annotationprocessingservice.domain.annotation.FragmentSelector;
 import eu.dissco.annotationprocessingservice.domain.annotation.HasRoi;
+import eu.dissco.annotationprocessingservice.domain.annotation.Target;
 import java.security.MessageDigest;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,60 +19,68 @@ import org.junit.jupiter.api.Test;
 
 class AnnotationHasherTest {
 
-    private AnnotationHasher annotationHasher;
+  private AnnotationHasher annotationHasher;
 
-    @BeforeEach
-    void setup() {
-      try {
-        this.annotationHasher = new AnnotationHasher(
-                MessageDigest.getInstance("MD5")
+  @BeforeEach
+  void setup() {
+    try {
+      this.annotationHasher = new AnnotationHasher(
+          MessageDigest.getInstance("MD5")
+      );
+    } catch (Exception ignored) {
+
+    }
+  }
+
+  @Test
+  void hashTestFieldValueSelector() {
+    // When
+    var result = annotationHasher.getAnnotationHash(givenAnnotationProcessed());
+
+    // Then
+    assertThat(result).isEqualTo(ANNOTATION_HASH);
+  }
+
+  @Test
+  void hashTestFragmentSelector() {
+    // Given
+    var selector = new FragmentSelector()
+        .withAcHasRoi(HasRoi.builder()
+            .heightFrac(0.1)
+            .widthFrac(0.1)
+            .valY(0.99)
+            .valX(0.99)
+            .build()
         );
-      } catch (Exception ignored){
 
-      }
-    }
+    var expected = UUID.fromString("a831698e-8bfd-4dbe-51c4-3236d0f2b047");
 
-    @Test
-    void hashTestFieldValueSelector() {
-        // When
-        var result = annotationHasher.getAnnotationHash(givenAnnotationProcessed());
+    // When
+    var result = annotationHasher.getAnnotationHash(
+        givenAnnotationProcessed().setOaTarget(
+            Target.builder()
+                .oaSelector(selector)
+                .odsId(HANDLE_PROXY + TARGET_ID)
+                .odsType(AnnotationTargetType.DIGITAL_SPECIMEN)
+                .build()));
 
-        // Then
-        assertThat(result).isEqualTo(ANNOTATION_HASH);
-    }
+    // Then
+    assertThat(result).isEqualTo(expected);
+  }
 
-    @Test
-    void hashTestFragmentSelector() {
-        // Given
-        var selector = new FragmentSelector()
-                .withAcHasRoi(new HasRoi()
-                        .withAcHeightFrac(0.1)
-                        .withAcWidthFrac(0.1)
-                        .withAcYFrac(0.99)
-                        .withAcXFrac(0.99)
-                );
+  @Test
+  void hashTestClassValueSelector() {
+    // Given
+    var selector = new ClassSelector()
+        .withOaClass("ClassName");
+    var expected = UUID.fromString("753ad133-4212-e03b-00e7-b757957901fd");
 
-        var expected = UUID.fromString("a831698e-8bfd-4dbe-51c4-3236d0f2b047");
+    // When
+    var result = annotationHasher.getAnnotationHash(
+        givenAnnotationProcessed().setOaTarget(givenOaTarget(TARGET_ID, AnnotationTargetType.DIGITAL_SPECIMEN, selector)));
 
-        // When
-        var result = annotationHasher.getAnnotationHash(givenAnnotationProcessed().setOaTarget(givenOaTarget(TARGET_ID).withSelector(selector)));
-
-        // Then
-        assertThat(result).isEqualTo(expected);
-    }
-
-    @Test
-    void hashTestClassValueSelector() {
-        // Given
-        var selector = new ClassSelector()
-                .withOaClass("ClassName"); 
-        var expected = UUID.fromString("753ad133-4212-e03b-00e7-b757957901fd");
-
-        // When
-        var result = annotationHasher.getAnnotationHash(givenAnnotationProcessed().setOaTarget(givenOaTarget(TARGET_ID).withSelector(selector)));
-
-        // Then
-        assertThat(result).isEqualTo(expected);
-    }
+    // Then
+    assertThat(result).isEqualTo(expected);
+  }
 
 }

--- a/src/test/java/eu/dissco/annotationprocessingservice/component/JsonPathComponentTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/component/JsonPathComponentTest.java
@@ -44,19 +44,22 @@ class JsonPathComponentTest {
       throws JsonProcessingException, BatchingException {
     // Given
     var expected = List.of(
-        new Target()
-            .withOdsId(DOI_PROXY + ID)
-            .withOdsType(AnnotationTargetType.DIGITAL_SPECIMEN)
-            .withSelector(new ClassSelector("digitalSpecimenWrapper.occurrences[0].locality")),
-        new Target()
-            .withOdsId(DOI_PROXY + ID)
-            .withOdsType(AnnotationTargetType.DIGITAL_SPECIMEN)
-            .withSelector(new ClassSelector("digitalSpecimenWrapper.occurrences[2].locality")));
+        Target.builder()
+            .odsId(DOI_PROXY + ID)
+            .odsType(AnnotationTargetType.DIGITAL_SPECIMEN)
+            .oaSelector(new ClassSelector("digitalSpecimenWrapper.occurrences[0].locality"))
+            .build(),
+        Target.builder()
+            .odsId(DOI_PROXY + ID)
+            .odsType(AnnotationTargetType.DIGITAL_SPECIMEN)
+            .oaSelector(new ClassSelector("digitalSpecimenWrapper.occurrences[2].locality"))
+            .build());
 
-    var baseTargetClassSelector = new Target()
-        .withOdsId(DOI_PROXY + ID)
-        .withOdsType(AnnotationTargetType.DIGITAL_SPECIMEN)
-        .withSelector(new ClassSelector("digitalSpecimenWrapper.occurrences[1].locality"));
+    var baseTargetClassSelector = Target.builder()
+        .odsId(DOI_PROXY + ID)
+        .odsType(AnnotationTargetType.DIGITAL_SPECIMEN)
+        .oaSelector(new ClassSelector("digitalSpecimenWrapper.occurrences[1].locality"))
+        .build();
 
     // When
     var result = jsonPathComponent.getAnnotationTargets(givenBatchMetadataLatitudeSearch(),
@@ -72,14 +75,16 @@ class JsonPathComponentTest {
       throws JsonProcessingException, BatchingException {
     // Given
     var baseTargetClassSelector = givenOaTarget(ID);
-    var expected = List.of(new Target()
-            .withOdsId(DOI_PROXY + ID)
-            .withOdsType(AnnotationTargetType.DIGITAL_SPECIMEN)
-            .withSelector(new FieldSelector("digitalSpecimenWrapper.occurrences[0].locality")),
-        new Target()
-            .withOdsId(DOI_PROXY + ID)
-            .withOdsType(AnnotationTargetType.DIGITAL_SPECIMEN)
-            .withSelector(new FieldSelector("digitalSpecimenWrapper.occurrences[2].locality")));
+    var expected = List.of(Target.builder()
+            .odsId(DOI_PROXY + ID)
+            .odsType(AnnotationTargetType.DIGITAL_SPECIMEN)
+            .oaSelector(new FieldSelector("digitalSpecimenWrapper.occurrences[0].locality"))
+            .build(),
+        Target.builder()
+            .odsId(DOI_PROXY + ID)
+            .odsType(AnnotationTargetType.DIGITAL_SPECIMEN)
+            .oaSelector(new FieldSelector("digitalSpecimenWrapper.occurrences[2].locality"))
+            .build());
 
     // When
     var result = jsonPathComponent.getAnnotationTargets(givenBatchMetadataLatitudeSearch(),
@@ -94,11 +99,12 @@ class JsonPathComponentTest {
   void testGetAnnotationTargetPathsBadBatchMetadata()
       throws JsonProcessingException {
     // Given
-    var baseTargetClassSelector = new Target()
-        .withOdsId(HANDLE_PROXY + ID)
-        .withOdsType(AnnotationTargetType.DIGITAL_SPECIMEN)
-        .withSelector(new ClassSelector()
-            .withOaClass("digitalSpecimenWrapper.occurrences[1].locality"));
+    var baseTargetClassSelector = Target.builder()
+        .odsId(HANDLE_PROXY + ID)
+        .odsType(AnnotationTargetType.DIGITAL_SPECIMEN)
+        .oaSelector(new ClassSelector()
+            .withOaClass("digitalSpecimenWrapper.occurrences[1].locality"))
+        .build();
     // Path is incorrect
     var batchMetadata = new BatchMetadata(
         1, "digitalSpecimenWrapper.occurrences[*].location.georeference.dwc:decimalLatitude", "11");
@@ -113,10 +119,11 @@ class JsonPathComponentTest {
   @Test
   void testBadSelectorType() {
     // Given
-    var baseTargetClassSelector = new Target()
-        .withOdsId(ID)
-        .withOdsType(AnnotationTargetType.DIGITAL_SPECIMEN)
-        .withSelector(new FragmentSelector());
+    var baseTargetClassSelector = Target.builder()
+        .odsId(ID)
+        .odsType(AnnotationTargetType.DIGITAL_SPECIMEN)
+        .oaSelector(new FragmentSelector())
+        .build();
 
     // When
     assertThrows(BatchingException.class, () ->
@@ -129,11 +136,12 @@ class JsonPathComponentTest {
   void testBadJsonpathFormat() throws JsonProcessingException {
     // Given
     var batchMetadata = new BatchMetadata(1, "[digitalSpecimenWrapper][occurrences][*][location][georeference]['dwc:decimalLatitude']['dwc:value']", "11");
-    var baseTargetClassSelector = new Target()
-        .withOdsId(ID)
-        .withOdsType(AnnotationTargetType.DIGITAL_SPECIMEN)
-        .withSelector(new FieldSelector()
-            .withOdsField("digitalSpecimenWrapper.occurrences[1].locality"));
+    var baseTargetClassSelector = Target.builder()
+        .odsId(ID)
+        .odsType(AnnotationTargetType.DIGITAL_SPECIMEN)
+        .oaSelector(new FieldSelector()
+            .withOdsField("digitalSpecimenWrapper.occurrences[1].locality"))
+        .build();
 
     // When
     assertThrows(BatchingException.class, () ->

--- a/src/test/java/eu/dissco/annotationprocessingservice/component/SchemaValidatorComponentTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/component/SchemaValidatorComponentTest.java
@@ -80,7 +80,7 @@ class SchemaValidatorComponentTest {
   @Test
   void testCreateMissingCreated() {
     // Given
-    var annotationRequest = givenAnnotationRequest().withDcTermsCreated(null);
+    var annotationRequest = givenAnnotationRequest().setDcTermsCreated(null);
 
     // Then
     assertThrows(AnnotationValidationException.class,
@@ -100,21 +100,21 @@ class SchemaValidatorComponentTest {
   private static Stream<Arguments> validAnnotations() {
     return Stream.of(
         Arguments.of(givenAnnotationRequest(), true),
-        Arguments.of(givenAnnotationRequest().withOdsId(ID), false)
+        Arguments.of(givenAnnotationRequest().setOdsId(ID), false)
     );
   }
 
   private static Stream<Arguments> invalidAnnotations() {
     return Stream.of(
-        Arguments.of(givenAnnotationRequest().withOaGenerated(CREATED)),
-        Arguments.of(givenAnnotationRequest().withAsGenerator(givenGenerator())),
-        Arguments.of(givenAnnotationRequest().withOdsId(ID)),
-        Arguments.of(givenAnnotationRequest().withOaCreator(null)),
-        Arguments.of(givenAnnotationRequest().withDcTermsCreated(null)),
-        Arguments.of(givenAnnotationRequest().withRdfType(null)),
-        Arguments.of(givenAnnotationRequest().withOaBody(null)),
-        Arguments.of(givenAnnotationRequest().withOaTarget(null)),
-        Arguments.of(givenAnnotationRequest().withOaMotivation(null))
+        Arguments.of(givenAnnotationRequest().setOaGenerated(CREATED)),
+        Arguments.of(givenAnnotationRequest().setAsGenerator(givenGenerator())),
+        Arguments.of(givenAnnotationRequest().setOdsId(ID)),
+        Arguments.of(givenAnnotationRequest().setOaCreator(null)),
+        Arguments.of(givenAnnotationRequest().setDcTermsCreated(null)),
+        Arguments.of(givenAnnotationRequest().setRdfType(null)),
+        Arguments.of(givenAnnotationRequest().setOaBody(null)),
+        Arguments.of(givenAnnotationRequest().setOaTarget(null)),
+        Arguments.of(givenAnnotationRequest().setOaMotivation(null))
     );
   }
 

--- a/src/test/java/eu/dissco/annotationprocessingservice/controller/AnnotationControllerTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/controller/AnnotationControllerTest.java
@@ -48,7 +48,7 @@ class AnnotationControllerTest {
   void testUpdateAnnotation()
       throws Exception {
     // Given
-    var request = givenAnnotationRequest().withOdsId(ID);
+    var request = givenAnnotationRequest().setOdsId(ID);
     given(service.updateAnnotation(request)).willReturn(givenAnnotationProcessed());
     var prefix = ID.split("/")[0];
     var suffix = ID.split("/")[1];
@@ -65,7 +65,7 @@ class AnnotationControllerTest {
   void testUpdateAnnotationIdMismatch()
       throws Exception {
     // Given
-    var request = givenAnnotationRequest().withOdsId(ID);
+    var request = givenAnnotationRequest().setOdsId(ID);
     var prefix = ID.split("/")[0];
     var suffix = "wrong";
 

--- a/src/test/java/eu/dissco/annotationprocessingservice/repository/AnnotationRepositoryIT.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/repository/AnnotationRepositoryIT.java
@@ -89,7 +89,7 @@ class AnnotationRepositoryIT extends BaseRepositoryIT {
     // Given
     var annotation = givenAnnotationProcessed();
     repository.createAnnotationRecord(annotation);
-    var updatedAnnotation = givenAnnotationProcessed().withOaMotivation(Motivation.EDITING);
+    var updatedAnnotation = givenAnnotationProcessed().setOaMotivation(Motivation.EDITING);
 
     // When
     repository.createAnnotationRecord(updatedAnnotation);
@@ -132,7 +132,7 @@ class AnnotationRepositoryIT extends BaseRepositoryIT {
   @Test
   void testGetAnnotationFromHash() {
     // Given
-    var altHashedAnnotation = new HashedAnnotation(givenAnnotationProcessed().withOdsId("alt id"),
+    var altHashedAnnotation = new HashedAnnotation(givenAnnotationProcessed().setOdsId("alt id"),
         ANNOTATION_HASH_2);
     repository.createAnnotationRecord(List.of(givenHashedAnnotation(), altHashedAnnotation));
 
@@ -212,23 +212,24 @@ class AnnotationRepositoryIT extends BaseRepositoryIT {
 
   private Annotation mapAnnotation(Record dbRecord) {
     try {
-      return new Annotation()
-          .withOdsId(dbRecord.get(ANNOTATION.ID))
-          .withRdfType(dbRecord.get(ANNOTATION.TYPE))
-          .withOdsVersion(dbRecord.get(ANNOTATION.VERSION))
-          .withOaMotivation(Motivation.fromString(dbRecord.get(ANNOTATION.MOTIVATION)))
-          .withOaMotivatedBy(dbRecord.get(ANNOTATION.MOTIVATED_BY))
-          .withOaTarget(mapper.readValue(dbRecord.get(ANNOTATION.TARGET).data(), Target.class))
-          .withOaBody(mapper.readValue(dbRecord.get(ANNOTATION.BODY).data(), Body.class))
-          .withOaCreator(mapper.readValue(dbRecord.get(ANNOTATION.CREATOR).data(), Creator.class))
-          .withDcTermsCreated(dbRecord.get(ANNOTATION.CREATED))
-          .withOdsDeletedOn(dbRecord.get(ANNOTATION.DELETED_ON))
-          .withAsGenerator(
+      return Annotation.builder()
+          .odsId(dbRecord.get(ANNOTATION.ID))
+          .rdfType(dbRecord.get(ANNOTATION.TYPE))
+          .odsVersion(dbRecord.get(ANNOTATION.VERSION))
+          .oaMotivation(Motivation.fromString(dbRecord.get(ANNOTATION.MOTIVATION)))
+          .oaMotivatedBy(dbRecord.get(ANNOTATION.MOTIVATED_BY))
+          .oaTarget(mapper.readValue(dbRecord.get(ANNOTATION.TARGET).data(), Target.class))
+          .oaBody(mapper.readValue(dbRecord.get(ANNOTATION.BODY).data(), Body.class))
+          .oaCreator(mapper.readValue(dbRecord.get(ANNOTATION.CREATOR).data(), Creator.class))
+          .dcTermsCreated(dbRecord.get(ANNOTATION.CREATED))
+          .odsDeletedOn(dbRecord.get(ANNOTATION.DELETED_ON))
+          .asGenerator(
               mapper.readValue(dbRecord.get(ANNOTATION.GENERATOR).data(), Generator.class))
-          .withOaGenerated(dbRecord.get(ANNOTATION.GENERATED))
-          .withOdsAggregateRating(mapper.readValue(dbRecord.get(ANNOTATION.AGGREGATE_RATING).data(),
+          .oaGenerated(dbRecord.get(ANNOTATION.GENERATED))
+          .odsAggregateRating(mapper.readValue(dbRecord.get(ANNOTATION.AGGREGATE_RATING).data(),
               AggregateRating.class))
-          .withOdsJobId(dbRecord.get(ANNOTATION.MJR_JOB_ID));
+          .odsJobId(dbRecord.get(ANNOTATION.MJR_JOB_ID))
+          .build();
     } catch (JsonProcessingException ignored) {
       return null;
     }

--- a/src/test/java/eu/dissco/annotationprocessingservice/repository/ElasticSearchRepositoryIT.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/repository/ElasticSearchRepositoryIT.java
@@ -120,7 +120,7 @@ class ElasticSearchRepositoryIT {
   void testIndexAnnotations() throws IOException {
     // Given
     var annotations = List.of(givenAnnotationProcessed(),
-        givenAnnotationProcessed().withOdsId("alt"));
+        givenAnnotationProcessed().setOdsId("alt"));
 
     // When
     var result = repository.indexAnnotations(annotations);

--- a/src/test/java/eu/dissco/annotationprocessingservice/service/BatchAnnotationServiceTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/service/BatchAnnotationServiceTest.java
@@ -99,7 +99,7 @@ class BatchAnnotationServiceTest {
   void testApplyBatchingSinglePageTwoBaseAnnotations() throws Exception {
     // Given
     int placeInBatch = 1;
-    var annotationBodyB = givenOaBody().withOaValue(List.of("Alt value"));
+    var annotationBodyB = givenOaBody("Alt value");
     var baseAnnotationA = givenAnnotationRequest().setPlaceInBatch(placeInBatch);
     var baseAnnotationB = givenAnnotationRequest().setPlaceInBatch(placeInBatch)
         .setOaBody(annotationBodyB);
@@ -154,7 +154,7 @@ class BatchAnnotationServiceTest {
     int placeInBatch = 1;
     var baseAnnotationA = givenAnnotationRequest().setPlaceInBatch(placeInBatch);
     var baseAnnotationB = givenAnnotationRequest().setPlaceInBatch(placeInBatch)
-        .setOaTarget(givenOaTarget(ID_ALT).withOdsType(AnnotationTargetType.MEDIA_OBJECT));
+        .setOaTarget(givenOaTarget(ID_ALT, AnnotationTargetType.MEDIA_OBJECT));
     var event = new AnnotationEvent(List.of(baseAnnotationA, baseAnnotationB), JOB_ID,
         List.of(givenBatchMetadataLatitudeSearch()), null);
 
@@ -173,8 +173,8 @@ class BatchAnnotationServiceTest {
     // Given
     var annotatableIdsA = List.of("0", "1", "2");
     var annotatableIdsB = List.of("3", "4", "5");
-    var annotationBodyB = givenOaBody().withOaValue(List.of("alt value"));
-    var annotationTargetB = givenOaTarget(ID_ALT).withOdsType(AnnotationTargetType.MEDIA_OBJECT);
+    var annotationBodyB = givenOaBody("alt value");
+    var annotationTargetB = givenOaTarget(ID_ALT, AnnotationTargetType.MEDIA_OBJECT);
     var batchMetadataA = givenBatchMetadataLatitudeSearch();
     var batchMetadataB = new BatchMetadata(2,
         "digitalSpecimenWrapper.occurrences[*].location.georeference.dwc:decimalLatitude.dwc:value",

--- a/src/test/java/eu/dissco/annotationprocessingservice/service/BatchAnnotationServiceTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/service/BatchAnnotationServiceTest.java
@@ -73,13 +73,14 @@ class BatchAnnotationServiceTest {
     int pageSizePlusOne = pageSize + 1;
     var elasticDocuments = annotatableIds.stream().map(TestUtils::givenElasticDocument).toList();
     var batchAnnotations = annotatableIds.stream().map(id ->
-        new Annotation()
-            .withOaBody(givenOaBody())
-            .withOaMotivation(Motivation.COMMENTING)
-            .withOaTarget(givenOaTarget(String.valueOf(id)))
-            .withDcTermsCreated(CREATED)
-            .withOaCreator(givenCreator(CREATOR))
-            .withOdsAggregateRating(givenAggregationRating())
+        Annotation.builder()
+            .oaBody(givenOaBody())
+            .oaMotivation(Motivation.COMMENTING)
+            .oaTarget(givenOaTarget(String.valueOf(id)))
+            .dcTermsCreated(CREATED)
+            .oaCreator(givenCreator(CREATOR))
+            .odsAggregateRating(givenAggregationRating())
+            .build()
     ).toList();
     var batchEvent = new AnnotationEvent(batchAnnotations, JOB_ID, null, true);
     givenJsonPathResponse(annotatableIds);
@@ -99,9 +100,9 @@ class BatchAnnotationServiceTest {
     // Given
     int placeInBatch = 1;
     var annotationBodyB = givenOaBody().withOaValue(List.of("Alt value"));
-    var baseAnnotationA = givenAnnotationRequest().withPlaceInBatch(placeInBatch);
-    var baseAnnotationB = givenAnnotationRequest().withPlaceInBatch(placeInBatch)
-        .withOaBody(annotationBodyB);
+    var baseAnnotationA = givenAnnotationRequest().setPlaceInBatch(placeInBatch);
+    var baseAnnotationB = givenAnnotationRequest().setPlaceInBatch(placeInBatch)
+        .setOaBody(annotationBodyB);
     var event = new AnnotationEvent(List.of(baseAnnotationA, baseAnnotationB), JOB_ID,
         List.of(givenBatchMetadataLatitudeSearch()), null);
 
@@ -111,22 +112,24 @@ class BatchAnnotationServiceTest {
     int pageSizePlusOne = pageSize + 1;
     var elasticDocuments = annotatableIds.stream().map(TestUtils::givenElasticDocument).toList();
     var batchAnnotationsA = annotatableIds.stream().map(id ->
-        new Annotation()
-            .withOaBody(givenOaBody())
-            .withOaMotivation(Motivation.COMMENTING)
-            .withOaTarget(givenOaTarget(String.valueOf(id)))
-            .withDcTermsCreated(CREATED)
-            .withOaCreator(givenCreator(CREATOR))
-            .withOdsAggregateRating(givenAggregationRating())
+        Annotation.builder()
+            .oaBody(givenOaBody())
+            .oaMotivation(Motivation.COMMENTING)
+            .oaTarget(givenOaTarget(String.valueOf(id)))
+            .dcTermsCreated(CREATED)
+            .oaCreator(givenCreator(CREATOR))
+            .odsAggregateRating(givenAggregationRating())
+            .build()
     ).toList();
     var batchAnnotationsB = annotatableIds.stream().map(id ->
-        new Annotation()
-            .withOaBody(annotationBodyB)
-            .withOaMotivation(Motivation.COMMENTING)
-            .withOaTarget(givenOaTarget(String.valueOf(id)))
-            .withDcTermsCreated(CREATED)
-            .withOaCreator(givenCreator(CREATOR))
-            .withOdsAggregateRating(givenAggregationRating())
+        Annotation.builder()
+            .oaBody(annotationBodyB)
+            .oaMotivation(Motivation.COMMENTING)
+            .oaTarget(givenOaTarget(String.valueOf(id)))
+            .dcTermsCreated(CREATED)
+            .oaCreator(givenCreator(CREATOR))
+            .odsAggregateRating(givenAggregationRating())
+            .build()
     ).toList();
 
     var batchEventA = new AnnotationEvent(batchAnnotationsA, JOB_ID, null, true);
@@ -149,9 +152,9 @@ class BatchAnnotationServiceTest {
   void testApplyBatchingTwoBaseAnnotationsTypeMismatch() {
     // Given
     int placeInBatch = 1;
-    var baseAnnotationA = givenAnnotationRequest().withPlaceInBatch(placeInBatch);
-    var baseAnnotationB = givenAnnotationRequest().withPlaceInBatch(placeInBatch)
-        .withOaTarget(givenOaTarget(ID_ALT).withOdsType(AnnotationTargetType.MEDIA_OBJECT));
+    var baseAnnotationA = givenAnnotationRequest().setPlaceInBatch(placeInBatch);
+    var baseAnnotationB = givenAnnotationRequest().setPlaceInBatch(placeInBatch)
+        .setOaTarget(givenOaTarget(ID_ALT).withOdsType(AnnotationTargetType.MEDIA_OBJECT));
     var event = new AnnotationEvent(List.of(baseAnnotationA, baseAnnotationB), JOB_ID,
         List.of(givenBatchMetadataLatitudeSearch()), null);
 
@@ -177,11 +180,11 @@ class BatchAnnotationServiceTest {
         "digitalSpecimenWrapper.occurrences[*].location.georeference.dwc:decimalLatitude.dwc:value",
         "12");
     var batchMetadataList = List.of(batchMetadataA, batchMetadataB);
-    var baseAnnotationA = givenAnnotationRequest().withPlaceInBatch(1);
+    var baseAnnotationA = givenAnnotationRequest().setPlaceInBatch(1);
     var baseAnnotationB = givenAnnotationRequest()
-        .withOaBody(annotationBodyB)
-        .withOaTarget(annotationTargetB)
-        .withPlaceInBatch(2);
+        .setOaBody(annotationBodyB)
+        .setOaTarget(annotationTargetB)
+        .setPlaceInBatch(2);
 
     var event = new AnnotationEvent(List.of(baseAnnotationA, baseAnnotationB), JOB_ID,
         batchMetadataList, false);
@@ -191,23 +194,25 @@ class BatchAnnotationServiceTest {
     var elasticDocumentsA = annotatableIdsA.stream().map(TestUtils::givenElasticDocument).toList();
     var elasticDocumentsB = annotatableIdsB.stream().map(TestUtils::givenElasticDocument).toList();
     var batchAnnotationsA = annotatableIdsA.stream().map(id ->
-        new Annotation()
-            .withOaBody(givenOaBody())
-            .withOaMotivation(Motivation.COMMENTING)
-            .withOaTarget(givenOaTarget(String.valueOf(id)))
-            .withDcTermsCreated(CREATED)
-            .withOaCreator(givenCreator(CREATOR))
-            .withOdsAggregateRating(givenAggregationRating())
+        Annotation.builder()
+            .oaBody(givenOaBody())
+            .oaMotivation(Motivation.COMMENTING)
+            .oaTarget(givenOaTarget(String.valueOf(id)))
+            .dcTermsCreated(CREATED)
+            .oaCreator(givenCreator(CREATOR))
+            .odsAggregateRating(givenAggregationRating())
+            .build()
     ).toList();
 
     var batchAnnotationsB = annotatableIdsB.stream().map(id ->
-        new Annotation()
-            .withOaBody(annotationBodyB)
-            .withOaMotivation(Motivation.COMMENTING)
-            .withOaTarget(givenOaTarget(String.valueOf(id)))
-            .withDcTermsCreated(CREATED)
-            .withOaCreator(givenCreator(CREATOR))
-            .withOdsAggregateRating(givenAggregationRating())
+        Annotation.builder()
+            .oaBody(annotationBodyB)
+            .oaMotivation(Motivation.COMMENTING)
+            .oaTarget(givenOaTarget(String.valueOf(id)))
+            .dcTermsCreated(CREATED)
+            .oaCreator(givenCreator(CREATOR))
+            .odsAggregateRating(givenAggregationRating())
+            .build()
     ).toList();
     var batchEventA = new AnnotationEvent(batchAnnotationsA, JOB_ID, null, true);
     var batchEventB = new AnnotationEvent(batchAnnotationsB, JOB_ID, null, true);

--- a/src/test/java/eu/dissco/annotationprocessingservice/service/FdoRecordServiceTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/service/FdoRecordServiceTest.java
@@ -122,8 +122,8 @@ class FdoRecordServiceTest {
 
   private static Stream<Arguments> handleNeedsUpdate() {
     return Stream.of(
-        Arguments.of(givenAnnotationProcessed().withOaMotivation(Motivation.EDITING)),
-        Arguments.of(givenAnnotationProcessed().withOaTarget(givenOaTarget("different target"))));
+        Arguments.of(givenAnnotationProcessed().setOaMotivation(Motivation.EDITING)),
+        Arguments.of(givenAnnotationProcessed().setOaTarget(givenOaTarget("different target"))));
   }
 
   @ParameterizedTest

--- a/src/test/java/eu/dissco/annotationprocessingservice/service/KafkaPublisherServiceTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/service/KafkaPublisherServiceTest.java
@@ -49,7 +49,7 @@ class KafkaPublisherServiceTest {
     // Given
 
     // When
-    service.publishUpdateEvent(givenAnnotationProcessed().withOaMotivation(Motivation.EDITING),
+    service.publishUpdateEvent(givenAnnotationProcessed().setOaMotivation(Motivation.EDITING),
         givenAnnotationProcessed());
 
     // Then

--- a/src/test/java/eu/dissco/annotationprocessingservice/service/ProcessingKafkaServiceTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/service/ProcessingKafkaServiceTest.java
@@ -17,7 +17,7 @@ import static eu.dissco.annotationprocessingservice.TestUtils.givenBatchMetadata
 import static eu.dissco.annotationprocessingservice.TestUtils.givenCreator;
 import static eu.dissco.annotationprocessingservice.TestUtils.givenHashedAnnotation;
 import static eu.dissco.annotationprocessingservice.TestUtils.givenHashedAnnotationAlt;
-import static eu.dissco.annotationprocessingservice.TestUtils.givenOaBody;
+import static eu.dissco.annotationprocessingservice.TestUtils.givenOaBodySetType;
 import static eu.dissco.annotationprocessingservice.TestUtils.givenOaTarget;
 import static eu.dissco.annotationprocessingservice.TestUtils.givenPatchRequest;
 import static eu.dissco.annotationprocessingservice.TestUtils.givenPostRequest;
@@ -373,7 +373,7 @@ class ProcessingKafkaServiceTest {
     var newAnnotation = givenAnnotationRequest();
     var changedAnnotationNew = (givenAnnotationRequest().setOaTarget(
         givenOaTarget("changedTarget")))
-        .setOaBody(new Body().withOaValue(List.of("new value")));
+        .setOaBody(Body.builder().oaValue(List.of("new value")).build());
     var changedAnnotationOriginal = (givenAnnotationProcessed().setOaTarget(
         givenOaTarget("changedTarget")).setOdsId(changedId));
     var changedAnnotationOriginalHashed = new HashedAnnotation(
@@ -442,12 +442,12 @@ class ProcessingKafkaServiceTest {
   private static Stream<Arguments> unequalAnnotations() {
     return Stream.of(
         Arguments.of(
-            givenAnnotationProcessed().setOaBody(givenOaBody().withOdsType("differentType"))),
+            givenAnnotationProcessed().setOaBody(givenOaBodySetType("differentType"))),
         Arguments.of(givenAnnotationProcessed().setOaCreator(givenCreator("different creator"))),
         Arguments.of(givenAnnotationProcessed().setOaTarget(givenOaTarget("different target"))),
         Arguments.of(givenAnnotationProcessed().setOaMotivatedBy("different motivated by")),
         Arguments.of(givenAnnotationProcessed().setOdsAggregateRating(
-            givenAggregationRating().withRatingValue(0.99))),
+            givenAggregationRating(0.99))),
         Arguments.of(givenAnnotationProcessed().setOaMotivation(Motivation.EDITING))
     );
   }

--- a/src/test/java/eu/dissco/annotationprocessingservice/service/ProcessingKafkaServiceTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/service/ProcessingKafkaServiceTest.java
@@ -210,7 +210,7 @@ class ProcessingKafkaServiceTest {
     // Given
     var annotation = givenAnnotationRequest();
     var secondAnnotation = givenAnnotationRequest()
-        .withOaTarget(givenOaTarget("alt target"));
+        .setOaTarget(givenOaTarget("alt target"));
     var event = new AnnotationEvent(List.of(annotation, secondAnnotation), JOB_ID, null, null);
     Map<UUID, String> idMap = Map.of(ANNOTATION_HASH, ID, ANNOTATION_HASH_2, ID_ALT);
     given(annotationHasher.getAnnotationHash(any())).willReturn(ANNOTATION_HASH)
@@ -371,16 +371,16 @@ class ProcessingKafkaServiceTest {
     String changedId = "changedId";
     var equalId = "equalId";
     var newAnnotation = givenAnnotationRequest();
-    var changedAnnotationNew = (givenAnnotationRequest().withOaTarget(
+    var changedAnnotationNew = (givenAnnotationRequest().setOaTarget(
         givenOaTarget("changedTarget")))
-        .withOaBody(new Body().withOaValue(List.of("new value")));
-    var changedAnnotationOriginal = (givenAnnotationProcessed().withOaTarget(
-        givenOaTarget("changedTarget")).withOdsId(changedId));
+        .setOaBody(new Body().withOaValue(List.of("new value")));
+    var changedAnnotationOriginal = (givenAnnotationProcessed().setOaTarget(
+        givenOaTarget("changedTarget")).setOdsId(changedId));
     var changedAnnotationOriginalHashed = new HashedAnnotation(
         changedAnnotationOriginal, ANNOTATION_HASH_2);
-    var equalAnnotation = givenAnnotationRequest().withOaTarget(givenOaTarget("equalTarget"));
+    var equalAnnotation = givenAnnotationRequest().setOaTarget(givenOaTarget("equalTarget"));
     var equalAnnotationHashed = new HashedAnnotation(
-        equalAnnotation.withOdsId(equalId).withOdsVersion(1), ANNOTATION_HASH_3);
+        equalAnnotation.setOdsId(equalId).setOdsVersion(1), ANNOTATION_HASH_3);
 
     given(annotationHasher.getAnnotationHash(any())).willReturn(ANNOTATION_HASH)
         .willReturn(ANNOTATION_HASH_2).willReturn(ANNOTATION_HASH_3);
@@ -442,13 +442,13 @@ class ProcessingKafkaServiceTest {
   private static Stream<Arguments> unequalAnnotations() {
     return Stream.of(
         Arguments.of(
-            givenAnnotationProcessed().withOaBody(givenOaBody().withOdsType("differentType"))),
-        Arguments.of(givenAnnotationProcessed().withOaCreator(givenCreator("different creator"))),
-        Arguments.of(givenAnnotationProcessed().withOaTarget(givenOaTarget("different target"))),
-        Arguments.of(givenAnnotationProcessed().withOaMotivatedBy("different motivated by")),
-        Arguments.of(givenAnnotationProcessed().withOdsAggregateRating(
+            givenAnnotationProcessed().setOaBody(givenOaBody().withOdsType("differentType"))),
+        Arguments.of(givenAnnotationProcessed().setOaCreator(givenCreator("different creator"))),
+        Arguments.of(givenAnnotationProcessed().setOaTarget(givenOaTarget("different target"))),
+        Arguments.of(givenAnnotationProcessed().setOaMotivatedBy("different motivated by")),
+        Arguments.of(givenAnnotationProcessed().setOdsAggregateRating(
             givenAggregationRating().withRatingValue(0.99))),
-        Arguments.of(givenAnnotationProcessed().withOaMotivation(Motivation.EDITING))
+        Arguments.of(givenAnnotationProcessed().setOaMotivation(Motivation.EDITING))
     );
   }
 
@@ -508,13 +508,13 @@ class ProcessingKafkaServiceTest {
     // Given
     var annotation = givenAnnotationRequest();
     var secondAnnotation = givenAnnotationProcessed()
-        .withOdsId(ID_ALT)
-        .withOaMotivatedBy("nature")
-        .withOaTarget(givenOaTarget("alt target"));
+        .setOdsId(ID_ALT)
+        .setOaMotivatedBy("nature")
+        .setOaTarget(givenOaTarget("alt target"));
     var secondAnnotationCurrent = givenAnnotationProcessed()
-        .withOdsId(ID_ALT)
-        .withOaMotivatedBy("science")
-        .withOaTarget(givenOaTarget("alt target"));
+        .setOdsId(ID_ALT)
+        .setOaMotivatedBy("science")
+        .setOaTarget(givenOaTarget("alt target"));
     var secondAnnotationCurrentHashed = new HashedAnnotation(secondAnnotationCurrent,
         ANNOTATION_HASH_2);
     var event = new AnnotationEvent(List.of(annotation, secondAnnotation), JOB_ID, null, null);
@@ -549,7 +549,7 @@ class ProcessingKafkaServiceTest {
   @Test
   void testHandleUpdateMessageKafkaException() throws Exception {
     // Given
-    var annotation = givenAnnotationRequest().withOdsId(ID);
+    var annotation = givenAnnotationRequest().setOdsId(ID);
     given(annotationHasher.getAnnotationHash(any())).willReturn(ANNOTATION_HASH);
     given(repository.getAnnotationFromHash(any())).willReturn(List.of(givenHashedAnnotationAlt()));
     given(bulkResponse.errors()).willReturn(false);
@@ -578,7 +578,7 @@ class ProcessingKafkaServiceTest {
   @Test
   void testUpdateMessageKafkaExceptionHandleRollbackFailed() throws Exception {
     // Given
-    var annotationRequest = givenAnnotationRequest().withOdsId(ID);
+    var annotationRequest = givenAnnotationRequest().setOdsId(ID);
     given(annotationHasher.getAnnotationHash(any())).willReturn(ANNOTATION_HASH);
     given(repository.getAnnotationFromHash(any())).willReturn(List.of(givenHashedAnnotationAlt()));
     given(bulkResponse.errors()).willReturn(false);
@@ -599,7 +599,7 @@ class ProcessingKafkaServiceTest {
     then(masJobRecordService).should().markMasJobRecordAsFailed(any(), eq(false));
     then(fdoRecordService).should(times(2))
         .buildPatchRollbackHandleRequest(
-            List.of(new HashedAnnotation(annotationRequest.withOdsVersion(2), ANNOTATION_HASH)));
+            List.of(new HashedAnnotation(annotationRequest.setOdsVersion(2), ANNOTATION_HASH)));
     then(handleComponent).should().updateHandle(any());
     then(handleComponent).should().rollbackHandleUpdate(any());
     then(elasticRepository).should(times(2)).indexAnnotations(anyList());

--- a/src/test/java/eu/dissco/annotationprocessingservice/service/ProcessingWebServiceTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/service/ProcessingWebServiceTest.java
@@ -220,7 +220,7 @@ class ProcessingWebServiceTest {
   @Test
   void testUpdateAnnotation() throws Exception {
     // Given
-    var annotationRequest = givenAnnotationRequest().withOdsId(ID);
+    var annotationRequest = givenAnnotationRequest().setOdsId(ID);
     given(repository.getAnnotationForUser(ID, CREATOR)).willReturn(
         Optional.of(givenAnnotationProcessedAlt()));
     var indexResponse = mock(IndexResponse.class);
@@ -232,19 +232,19 @@ class ProcessingWebServiceTest {
     var result = service.updateAnnotation(annotationRequest);
 
     // Then
-    assertThat(result).isEqualTo(givenAnnotationProcessedWeb().withOdsVersion(2));
+    assertThat(result).isEqualTo(givenAnnotationProcessedWeb().setOdsVersion(2));
     assertThat(result.getOdsId()).isEqualTo(ID);
     then(fdoRecordService).should().buildPatchRollbackHandleRequest(annotationRequest);
     then(handleComponent).should().updateHandle(any());
     then(kafkaPublisherService).should()
         .publishUpdateEvent(givenAnnotationProcessedAlt(),
-            givenAnnotationProcessedWeb().withOdsVersion(2));
+            givenAnnotationProcessedWeb().setOdsVersion(2));
   }
 
   @Test
   void testUpdateEqualAnnotation() throws Exception {
     // Given
-    var annotationRequest = givenAnnotationRequest().withOdsId(ID);
+    var annotationRequest = givenAnnotationRequest().setOdsId(ID);
     var currentResult = givenAnnotationProcessedWeb();
     given(repository.getAnnotationForUser(ID, CREATOR)).willReturn(
         Optional.of(currentResult));
@@ -264,7 +264,7 @@ class ProcessingWebServiceTest {
   @Test
   void testUpdateAnnotationNotFound() {
     // Given
-    var annotationRequest = givenAnnotationRequest().withOdsId(ID);
+    var annotationRequest = givenAnnotationRequest().setOdsId(ID);
     given(repository.getAnnotationForUser(ID, CREATOR)).willReturn(Optional.empty());
 
     // Then
@@ -274,7 +274,7 @@ class ProcessingWebServiceTest {
   @Test
   void testUpdateAnnotationPidException() throws Exception {
     // Given
-    var annotationRequest = givenAnnotationRequest().withOdsId(ID);
+    var annotationRequest = givenAnnotationRequest().setOdsId(ID);
     given(repository.getAnnotationForUser(ID, CREATOR)).willReturn(
         Optional.of(givenAnnotationProcessedAlt()));
     given(fdoRecordService.handleNeedsUpdate(any(), any())).willReturn(true);
@@ -293,7 +293,7 @@ class ProcessingWebServiceTest {
   @Test
   void testUpdateAnnotationElasticIOException() throws Exception {
     // Given
-    var annotationRequest = givenAnnotationRequest().withOdsId(ID);
+    var annotationRequest = givenAnnotationRequest().setOdsId(ID);
     given(repository.getAnnotationForUser(ID, CREATOR)).willReturn(
         Optional.of(givenAnnotationProcessedAlt()));
     doThrow(IOException.class).when(elasticRepository).indexAnnotation(any(Annotation.class));
@@ -314,7 +314,7 @@ class ProcessingWebServiceTest {
   @Test
   void testUpdateAnnotationElasticFailure() throws Exception {
     // Given
-    var annotationRequest = givenAnnotationRequest().withOdsId(ID);
+    var annotationRequest = givenAnnotationRequest().setOdsId(ID);
     given(repository.getAnnotationForUser(ID, CREATOR)).willReturn(
         Optional.of(givenAnnotationProcessedAlt()));
     var indexResponse = mock(IndexResponse.class);
@@ -337,7 +337,7 @@ class ProcessingWebServiceTest {
   @Test
   void testUpdateAnnotationKafkaFailure() throws Exception {
     // Given
-    var annotationRequest = givenAnnotationRequest().withOdsId(ID);
+    var annotationRequest = givenAnnotationRequest().setOdsId(ID);
     given(repository.getAnnotationForUser(ID, CREATOR)).willReturn(
         Optional.of(givenAnnotationProcessedAlt()));
     var indexResponse = mock(IndexResponse.class);
@@ -346,7 +346,7 @@ class ProcessingWebServiceTest {
     given(fdoRecordService.handleNeedsUpdate(any(), any())).willReturn(true);
     doThrow(JsonProcessingException.class).when(kafkaPublisherService)
         .publishUpdateEvent(givenAnnotationProcessedAlt(),
-            givenAnnotationProcessedWeb().withOdsVersion(2));
+            givenAnnotationProcessedWeb().setOdsVersion(2));
 
     // When
     assertThrows(FailedProcessingException.class,
@@ -375,7 +375,7 @@ class ProcessingWebServiceTest {
 
   @Test
   void testDataAccessExceptionUpdateAnnotation() throws Exception {
-    var annotationRequest = givenAnnotationRequest().withOdsId(ID);
+    var annotationRequest = givenAnnotationRequest().setOdsId(ID);
     given(repository.getAnnotationForUser(ID, CREATOR)).willReturn(
         Optional.of(givenAnnotationProcessedAlt()));
     given(fdoRecordService.handleNeedsUpdate(any(), any())).willReturn(true);


### PR DESCRIPTION
Uses lombok @builder to clean up `annotation` object code. 

Makes annotation components (e.g. `target`, `body`) immutable. 

`Selector` and its inheritors was left alone because of the inheritance