### PR TITLE
Handle request uses PID for Type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.4</version>
+    <version>3.2.5</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>eu.dissco.core</groupId>

--- a/src/main/java/eu/dissco/annotationprocessingservice/domain/FdoProfileAttributes.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/domain/FdoProfileAttributes.java
@@ -5,12 +5,10 @@ import lombok.Getter;
 @Getter
 public enum FdoProfileAttributes {
 
-  TYPE("type", "annotation"),
-  FDO_PROFILE("fdoProfile", "https://hdl.handle.net/21.T11148/64396cf36b976ad08267"),
-  DIGITAL_OBJECT_TYPE("digitalObjectType", "https://hdl.handle.net/21.T11148/64396cf36b976ad08267"),
+  TYPE("type", "https://hdl.handle.net/21.T11148/cf458ca9ee1d44a5608f"),
+  FDO_PROFILE("fdoProfile", "https://hdl.handle.net/21.T11148/cf458ca9ee1d44a5608f"),
   // Issued for agent should be DiSSCo PID; currently it's set as Naturalis's ROR
   ISSUED_FOR_AGENT("issuedForAgent", "https://ror.org/0566bfb96"),
-
   TARGET_PID("targetPid", null),
   TARGET_TYPE("targetType", null),
   MOTIVATION("motivation", null),

--- a/src/main/java/eu/dissco/annotationprocessingservice/domain/FdoProfileAttributes.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/domain/FdoProfileAttributes.java
@@ -5,21 +5,18 @@ import lombok.Getter;
 @Getter
 public enum FdoProfileAttributes {
 
-  TYPE("type", "https://hdl.handle.net/21.T11148/cf458ca9ee1d44a5608f"),
-  FDO_PROFILE("fdoProfile", "https://hdl.handle.net/21.T11148/cf458ca9ee1d44a5608f"),
+  TYPE("type"),
   // Issued for agent should be DiSSCo PID; currently it's set as Naturalis's ROR
-  ISSUED_FOR_AGENT("issuedForAgent", "https://ror.org/0566bfb96"),
-  TARGET_PID("targetPid", null),
-  TARGET_TYPE("targetType", null),
-  MOTIVATION("motivation", null),
-  ANNOTATION_HASH("annotationHash", null);
+  ISSUED_FOR_AGENT("issuedForAgent"),
+  TARGET_PID("targetPid"),
+  TARGET_TYPE("targetType"),
+  MOTIVATION("motivation"),
+  ANNOTATION_HASH("annotationHash");
 
   private final String attribute;
-  private final String defaultValue;
 
-  private FdoProfileAttributes(String attribute, String defaultValue) {
+  private FdoProfileAttributes(String attribute) {
     this.attribute = attribute;
-    this.defaultValue = defaultValue;
   }
 
 }

--- a/src/main/java/eu/dissco/annotationprocessingservice/properties/FdoProperties.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/properties/FdoProperties.java
@@ -1,0 +1,18 @@
+package eu.dissco.annotationprocessingservice.properties;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Data
+@Validated
+@ConfigurationProperties("fdo")
+public class FdoProperties {
+  @NotBlank
+  private String type = "https://hdl.handle.net/21.T11148/cf458ca9ee1d44a5608f";
+
+  @NotBlank
+  private String issuedForAgent = "https://ror.org/0566bfb96";
+
+}

--- a/src/main/java/eu/dissco/annotationprocessingservice/service/FdoRecordService.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/service/FdoRecordService.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import eu.dissco.annotationprocessingservice.domain.HashedAnnotation;
 import eu.dissco.annotationprocessingservice.domain.annotation.Annotation;
+import eu.dissco.annotationprocessingservice.properties.FdoProperties;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -25,11 +26,10 @@ public class FdoRecordService {
 
   private final ObjectMapper mapper;
 
+  private final FdoProperties fdoProperties;
   private static final String ATTRIBUTES = "attributes";
   private static final String DATA = "data";
   private static final String ID = "id";
-  private static final String FDO_TYPE = "https://hdl.handle.net/21.T11148/cf458ca9ee1d44a5608f";
-  private static final String ISSUED_FOR_AGENT_ROR = "https://ror.org/0566bfb96";
 
   public List<JsonNode> buildPostHandleRequest(Annotation annotation) {
     return List.of(buildSinglePostHandleRequest(annotation, null));
@@ -47,7 +47,7 @@ public class FdoRecordService {
     var request = mapper.createObjectNode();
     var data = mapper.createObjectNode();
     var attributes = generateAttributes(annotation, annotationHash);
-    data.put(TYPE.getAttribute(), FDO_TYPE);
+    data.put(TYPE.getAttribute(), fdoProperties.getType());
     data.set(ATTRIBUTES, attributes);
     request.set(DATA, data);
     return request;
@@ -69,7 +69,7 @@ public class FdoRecordService {
     var request = mapper.createObjectNode();
     var data = mapper.createObjectNode();
     var attributes = generateAttributes(annotation, annotationHash);
-    data.put(TYPE.getAttribute(), FDO_TYPE);
+    data.put(TYPE.getAttribute(), fdoProperties.getType());
     data.set(ATTRIBUTES, attributes);
     data.put(ID, annotation.getOdsId());
     request.set(DATA, data);
@@ -89,7 +89,7 @@ public class FdoRecordService {
 
   private JsonNode generateAttributes(Annotation annotation, UUID annotationHash) {
     var attributes = mapper.createObjectNode();
-    attributes.put(ISSUED_FOR_AGENT.getAttribute(), ISSUED_FOR_AGENT_ROR);
+    attributes.put(ISSUED_FOR_AGENT.getAttribute(), fdoProperties.getIssuedForAgent());
     attributes.put(TARGET_PID.getAttribute(), annotation.getOaTarget().getOdsId());
     attributes.put(TARGET_TYPE.getAttribute(), annotation.getOaTarget().getOdsType().toString());
     attributes.put(MOTIVATION.getAttribute(), annotation.getOaMotivation().toString());

--- a/src/main/java/eu/dissco/annotationprocessingservice/service/FdoRecordService.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/service/FdoRecordService.java
@@ -1,7 +1,6 @@
 package eu.dissco.annotationprocessingservice.service;
 
 import static eu.dissco.annotationprocessingservice.domain.FdoProfileAttributes.ANNOTATION_HASH;
-import static eu.dissco.annotationprocessingservice.domain.FdoProfileAttributes.FDO_PROFILE;
 import static eu.dissco.annotationprocessingservice.domain.FdoProfileAttributes.ISSUED_FOR_AGENT;
 import static eu.dissco.annotationprocessingservice.domain.FdoProfileAttributes.MOTIVATION;
 import static eu.dissco.annotationprocessingservice.domain.FdoProfileAttributes.TARGET_PID;
@@ -29,6 +28,8 @@ public class FdoRecordService {
   private static final String ATTRIBUTES = "attributes";
   private static final String DATA = "data";
   private static final String ID = "id";
+  private static final String FDO_TYPE = "https://hdl.handle.net/21.T11148/cf458ca9ee1d44a5608f";
+  private static final String ISSUED_FOR_AGENT_ROR = "https://ror.org/0566bfb96";
 
   public List<JsonNode> buildPostHandleRequest(Annotation annotation) {
     return List.of(buildSinglePostHandleRequest(annotation, null));
@@ -46,7 +47,7 @@ public class FdoRecordService {
     var request = mapper.createObjectNode();
     var data = mapper.createObjectNode();
     var attributes = generateAttributes(annotation, annotationHash);
-    data.put(TYPE.getAttribute(), TYPE.getDefaultValue());
+    data.put(TYPE.getAttribute(), FDO_TYPE);
     data.set(ATTRIBUTES, attributes);
     request.set(DATA, data);
     return request;
@@ -68,7 +69,7 @@ public class FdoRecordService {
     var request = mapper.createObjectNode();
     var data = mapper.createObjectNode();
     var attributes = generateAttributes(annotation, annotationHash);
-    data.put(TYPE.getAttribute(), TYPE.getDefaultValue());
+    data.put(TYPE.getAttribute(), FDO_TYPE);
     data.set(ATTRIBUTES, attributes);
     data.put(ID, annotation.getOdsId());
     request.set(DATA, data);
@@ -88,8 +89,7 @@ public class FdoRecordService {
 
   private JsonNode generateAttributes(Annotation annotation, UUID annotationHash) {
     var attributes = mapper.createObjectNode();
-    attributes.put(FDO_PROFILE.getAttribute(), FDO_PROFILE.getDefaultValue());
-    attributes.put(ISSUED_FOR_AGENT.getAttribute(), ISSUED_FOR_AGENT.getDefaultValue());
+    attributes.put(ISSUED_FOR_AGENT.getAttribute(), ISSUED_FOR_AGENT_ROR);
     attributes.put(TARGET_PID.getAttribute(), annotation.getOaTarget().getOdsId());
     attributes.put(TARGET_TYPE.getAttribute(), annotation.getOaTarget().getOdsType().toString());
     attributes.put(MOTIVATION.getAttribute(), annotation.getOaMotivation().toString());

--- a/src/main/java/eu/dissco/annotationprocessingservice/service/FdoRecordService.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/service/FdoRecordService.java
@@ -1,7 +1,6 @@
 package eu.dissco.annotationprocessingservice.service;
 
 import static eu.dissco.annotationprocessingservice.domain.FdoProfileAttributes.ANNOTATION_HASH;
-import static eu.dissco.annotationprocessingservice.domain.FdoProfileAttributes.DIGITAL_OBJECT_TYPE;
 import static eu.dissco.annotationprocessingservice.domain.FdoProfileAttributes.FDO_PROFILE;
 import static eu.dissco.annotationprocessingservice.domain.FdoProfileAttributes.ISSUED_FOR_AGENT;
 import static eu.dissco.annotationprocessingservice.domain.FdoProfileAttributes.MOTIVATION;
@@ -90,7 +89,6 @@ public class FdoRecordService {
   private JsonNode generateAttributes(Annotation annotation, UUID annotationHash) {
     var attributes = mapper.createObjectNode();
     attributes.put(FDO_PROFILE.getAttribute(), FDO_PROFILE.getDefaultValue());
-    attributes.put(DIGITAL_OBJECT_TYPE.getAttribute(), DIGITAL_OBJECT_TYPE.getDefaultValue());
     attributes.put(ISSUED_FOR_AGENT.getAttribute(), ISSUED_FOR_AGENT.getDefaultValue());
     attributes.put(TARGET_PID.getAttribute(), annotation.getOaTarget().getOdsId());
     attributes.put(TARGET_TYPE.getAttribute(), annotation.getOaTarget().getOdsType().toString());

--- a/src/test/java/eu/dissco/annotationprocessingservice/TestUtils.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/TestUtils.java
@@ -159,7 +159,6 @@ public class TestUtils {
             "data": {
               "type": "https://hdl.handle.net/21.T11148/cf458ca9ee1d44a5608f",
               "attributes": {
-               "fdoProfile": "https://hdl.handle.net/21.T11148/cf458ca9ee1d44a5608f",
                "issuedForAgent": "https://ror.org/0566bfb96",
                "targetPid":"https://hdl.handle.net/20.5000.1025/QRS-123-ABC",
                "targetType":"https://doi.org/21.T11148/894b1e6cad57e921764e",
@@ -176,7 +175,6 @@ public class TestUtils {
             "data": {
               "type": "https://hdl.handle.net/21.T11148/cf458ca9ee1d44a5608f",
               "attributes": {
-               "fdoProfile": "https://hdl.handle.net/21.T11148/cf458ca9ee1d44a5608f",
                "issuedForAgent": "https://ror.org/0566bfb96",
                "targetPid":"https://hdl.handle.net/20.5000.1025/QRS-123-ABC",
                "targetType":"https://doi.org/21.T11148/894b1e6cad57e921764e",
@@ -191,7 +189,6 @@ public class TestUtils {
             "data": {
               "type": "https://hdl.handle.net/21.T11148/cf458ca9ee1d44a5608f",
               "attributes": {
-               "fdoProfile": "https://hdl.handle.net/21.T11148/cf458ca9ee1d44a5608f",
                "issuedForAgent": "https://ror.org/0566bfb96",
                "targetPid":"https://hdl.handle.net/20.5000.1025/QRS-123-ABC",
                "targetType":"https://doi.org/21.T11148/894b1e6cad57e921764e",
@@ -210,7 +207,6 @@ public class TestUtils {
             "data": {
               "type": "https://hdl.handle.net/21.T11148/cf458ca9ee1d44a5608f",
               "attributes": {
-               "fdoProfile": "https://hdl.handle.net/21.T11148/cf458ca9ee1d44a5608f",
                 "issuedForAgent": "https://ror.org/0566bfb96",
                 "targetPid":"https://hdl.handle.net/20.5000.1025/QRS-123-ABC",
                 "targetType":"https://doi.org/21.T11148/894b1e6cad57e921764e",
@@ -228,7 +224,6 @@ public class TestUtils {
             "data": {
               "type": "https://hdl.handle.net/21.T11148/cf458ca9ee1d44a5608f",
               "attributes": {
-               "fdoProfile": "https://hdl.handle.net/21.T11148/cf458ca9ee1d44a5608f",
                 "issuedForAgent": "https://ror.org/0566bfb96",
                 "targetPid":"https://hdl.handle.net/20.5000.1025/QRS-123-ABC",
                 "targetType":"https://doi.org/21.T11148/894b1e6cad57e921764e",
@@ -244,7 +239,6 @@ public class TestUtils {
             "data": {
               "type": "https://hdl.handle.net/21.T11148/cf458ca9ee1d44a5608f",
               "attributes": {
-               "fdoProfile": "https://hdl.handle.net/21.T11148/cf458ca9ee1d44a5608f",
                "issuedForAgent": "https://ror.org/0566bfb96",
                "targetPid":"https://hdl.handle.net/20.5000.1025/QRS-123-ABC",
                "targetType":"https://doi.org/21.T11148/894b1e6cad57e921764e",

--- a/src/test/java/eu/dissco/annotationprocessingservice/TestUtils.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/TestUtils.java
@@ -157,10 +157,9 @@ public class TestUtils {
     return List.of(MAPPER.readTree("""
         {
             "data": {
-              "type": "annotation",
+              "type": "https://hdl.handle.net/21.T11148/cf458ca9ee1d44a5608f",
               "attributes": {
-               "fdoProfile": "https://hdl.handle.net/21.T11148/64396cf36b976ad08267",
-               "digitalObjectType": "https://hdl.handle.net/21.T11148/64396cf36b976ad08267",
+               "fdoProfile": "https://hdl.handle.net/21.T11148/cf458ca9ee1d44a5608f",
                "issuedForAgent": "https://ror.org/0566bfb96",
                "targetPid":"https://hdl.handle.net/20.5000.1025/QRS-123-ABC",
                "targetType":"https://doi.org/21.T11148/894b1e6cad57e921764e",
@@ -175,10 +174,9 @@ public class TestUtils {
     var jsonNode = MAPPER.readTree("""
         {
             "data": {
-              "type": "annotation",
+              "type": "https://hdl.handle.net/21.T11148/cf458ca9ee1d44a5608f",
               "attributes": {
-               "fdoProfile": "https://hdl.handle.net/21.T11148/64396cf36b976ad08267",
-               "digitalObjectType": "https://hdl.handle.net/21.T11148/64396cf36b976ad08267",
+               "fdoProfile": "https://hdl.handle.net/21.T11148/cf458ca9ee1d44a5608f",
                "issuedForAgent": "https://ror.org/0566bfb96",
                "targetPid":"https://hdl.handle.net/20.5000.1025/QRS-123-ABC",
                "targetType":"https://doi.org/21.T11148/894b1e6cad57e921764e",
@@ -191,10 +189,9 @@ public class TestUtils {
     var jsonNode2 = MAPPER.readTree("""
         {
             "data": {
-              "type": "annotation",
+              "type": "https://hdl.handle.net/21.T11148/cf458ca9ee1d44a5608f",
               "attributes": {
-               "fdoProfile": "https://hdl.handle.net/21.T11148/64396cf36b976ad08267",
-               "digitalObjectType": "https://hdl.handle.net/21.T11148/64396cf36b976ad08267",
+               "fdoProfile": "https://hdl.handle.net/21.T11148/cf458ca9ee1d44a5608f",
                "issuedForAgent": "https://ror.org/0566bfb96",
                "targetPid":"https://hdl.handle.net/20.5000.1025/QRS-123-ABC",
                "targetType":"https://doi.org/21.T11148/894b1e6cad57e921764e",
@@ -211,10 +208,9 @@ public class TestUtils {
     return List.of(MAPPER.readTree("""
         {
             "data": {
-              "type": "annotation",
+              "type": "https://hdl.handle.net/21.T11148/cf458ca9ee1d44a5608f",
               "attributes": {
-               "fdoProfile": "https://hdl.handle.net/21.T11148/64396cf36b976ad08267",
-                "digitalObjectType": "https://hdl.handle.net/21.T11148/64396cf36b976ad08267",
+               "fdoProfile": "https://hdl.handle.net/21.T11148/cf458ca9ee1d44a5608f",
                 "issuedForAgent": "https://ror.org/0566bfb96",
                 "targetPid":"https://hdl.handle.net/20.5000.1025/QRS-123-ABC",
                 "targetType":"https://doi.org/21.T11148/894b1e6cad57e921764e",
@@ -230,10 +226,9 @@ public class TestUtils {
     var node1 = MAPPER.readTree("""
         {
             "data": {
-              "type": "annotation",
+              "type": "https://hdl.handle.net/21.T11148/cf458ca9ee1d44a5608f",
               "attributes": {
-               "fdoProfile": "https://hdl.handle.net/21.T11148/64396cf36b976ad08267",
-                "digitalObjectType": "https://hdl.handle.net/21.T11148/64396cf36b976ad08267",
+               "fdoProfile": "https://hdl.handle.net/21.T11148/cf458ca9ee1d44a5608f",
                 "issuedForAgent": "https://ror.org/0566bfb96",
                 "targetPid":"https://hdl.handle.net/20.5000.1025/QRS-123-ABC",
                 "targetType":"https://doi.org/21.T11148/894b1e6cad57e921764e",
@@ -247,10 +242,9 @@ public class TestUtils {
     var node2 = MAPPER.readTree("""
           {
             "data": {
-              "type": "annotation",
+              "type": "https://hdl.handle.net/21.T11148/cf458ca9ee1d44a5608f",
               "attributes": {
-               "fdoProfile": "https://hdl.handle.net/21.T11148/64396cf36b976ad08267",
-               "digitalObjectType": "https://hdl.handle.net/21.T11148/64396cf36b976ad08267",
+               "fdoProfile": "https://hdl.handle.net/21.T11148/cf458ca9ee1d44a5608f",
                "issuedForAgent": "https://ror.org/0566bfb96",
                "targetPid":"https://hdl.handle.net/20.5000.1025/QRS-123-ABC",
                "targetType":"https://doi.org/21.T11148/894b1e6cad57e921764e",

--- a/src/test/java/eu/dissco/annotationprocessingservice/component/JsonPathComponentTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/component/JsonPathComponentTest.java
@@ -96,8 +96,7 @@ class JsonPathComponentTest {
   }
 
   @Test
-  void testGetAnnotationTargetPathsBadBatchMetadata()
-      throws JsonProcessingException {
+  void testGetAnnotationTargetPathsBadBatchMetadata() {
     // Given
     var baseTargetClassSelector = Target.builder()
         .odsId(HANDLE_PROXY + ID)
@@ -133,7 +132,7 @@ class JsonPathComponentTest {
   }
 
   @Test
-  void testBadJsonpathFormat() throws JsonProcessingException {
+  void testBadJsonpathFormat() {
     // Given
     var batchMetadata = new BatchMetadata(1, "[digitalSpecimenWrapper][occurrences][*][location][georeference]['dwc:decimalLatitude']['dwc:value']", "11");
     var baseTargetClassSelector = Target.builder()

--- a/src/test/java/eu/dissco/annotationprocessingservice/component/SchemaValidatorComponentTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/component/SchemaValidatorComponentTest.java
@@ -8,11 +8,9 @@ import static eu.dissco.annotationprocessingservice.TestUtils.givenAnnotationReq
 import static eu.dissco.annotationprocessingservice.TestUtils.givenGenerator;
 import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.mockito.BDDMockito.given;
 
 import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.SpecVersion.VersionFlag;
-import eu.dissco.annotationprocessingservice.Profiles;
 import eu.dissco.annotationprocessingservice.domain.AnnotationEvent;
 import eu.dissco.annotationprocessingservice.domain.annotation.Annotation;
 import eu.dissco.annotationprocessingservice.exception.AnnotationValidationException;

--- a/src/test/java/eu/dissco/annotationprocessingservice/controller/AnnotationControllerTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/controller/AnnotationControllerTest.java
@@ -62,8 +62,7 @@ class AnnotationControllerTest {
   }
 
   @Test
-  void testUpdateAnnotationIdMismatch()
-      throws Exception {
+  void testUpdateAnnotationIdMismatch() {
     // Given
     var request = givenAnnotationRequest().setOdsId(ID);
     var prefix = ID.split("/")[0];

--- a/src/test/java/eu/dissco/annotationprocessingservice/repository/ElasticSearchRepositoryIT.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/repository/ElasticSearchRepositoryIT.java
@@ -16,7 +16,6 @@ import co.elastic.clients.json.jackson.JacksonJsonpMapper;
 import co.elastic.clients.transport.ElasticsearchTransport;
 import co.elastic.clients.transport.rest_client.RestClientTransport;
 import com.fasterxml.jackson.databind.JsonNode;
-import eu.dissco.annotationprocessingservice.domain.BatchMetadata;
 import eu.dissco.annotationprocessingservice.domain.annotation.AnnotationTargetType;
 import eu.dissco.annotationprocessingservice.properties.ElasticSearchProperties;
 import java.io.IOException;
@@ -230,41 +229,6 @@ class ElasticSearchRepositoryIT {
     }
     client.bulk(bulkRequest.build());
     client.indices().refresh(b -> b.index(index));
-  }
-
-  private JsonNode givenElasticOnlyOneOccurrence() throws Exception {
-    return MAPPER.readTree("""
-        {
-          "id": "20.5000.1025/AAA-BBB-CCC",
-          "digitalSpecimenWrapper": {
-            "fieldNum": 1,
-            "other": [
-              "a",
-              "10"
-            ],
-            "occurrences": [
-              {
-                "dwc:occurrenceRemarks": "Correct",
-                "annotateTarget": "this",
-                "hello":"hello",
-                "location": {
-                  "dwc:country": "netherlands",
-                  "georeference": {
-                    "dwc:decimalLatitude": {
-                      "dwc:value": 11
-                    },
-                    "dwc:decimalLongitude": "10",
-                    "dwc": [
-                      "1"
-                    ]
-                  },
-                  "locality": "known"
-                }
-              }
-            ]
-          }
-        }
-        """);
   }
 
 }

--- a/src/test/java/eu/dissco/annotationprocessingservice/service/FdoRecordServiceTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/service/FdoRecordServiceTest.java
@@ -16,6 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import eu.dissco.annotationprocessingservice.domain.annotation.Annotation;
 import eu.dissco.annotationprocessingservice.domain.annotation.Motivation;
+import eu.dissco.annotationprocessingservice.properties.FdoProperties;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,7 +31,7 @@ class FdoRecordServiceTest {
 
   @BeforeEach
   void setUp() {
-    fdoRecordService = new FdoRecordService(MAPPER);
+    fdoRecordService = new FdoRecordService(MAPPER, new FdoProperties());
   }
 
   @Test

--- a/src/test/java/eu/dissco/annotationprocessingservice/service/ProcessingWebServiceTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/service/ProcessingWebServiceTest.java
@@ -9,7 +9,6 @@ import static eu.dissco.annotationprocessingservice.TestUtils.givenAnnotationReq
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.doThrow;
@@ -162,6 +161,7 @@ class ProcessingWebServiceTest {
     var indexResponse = mock(IndexResponse.class);
     given(indexResponse.result()).willReturn(Result.NotFound);
     given(elasticRepository.indexAnnotation(givenAnnotationProcessedWeb())).willReturn(indexResponse);
+    doThrow(PidCreationException.class).when(handleComponent).rollbackHandleCreation(any());
     given(applicationProperties.getProcessorHandle()).willReturn(
         "https://hdl.handle.net/anno-process-service-pid");
 

--- a/src/test/java/eu/dissco/annotationprocessingservice/web/HandleComponentTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/web/HandleComponentTest.java
@@ -156,7 +156,7 @@ class HandleComponentTest {
   }
 
   @Test
-  void testArchiveHandle() throws Exception {
+  void testArchiveHandle() {
     // Given
     var requestBody = MAPPER.createObjectNode();
     mockHandleServer.enqueue(new MockResponse().setResponseCode(HttpStatus.OK.value())

--- a/src/test/java/eu/dissco/annotationprocessingservice/web/HandleComponentTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/web/HandleComponentTest.java
@@ -269,7 +269,6 @@ class HandleComponentTest {
             "type": "mediaObject",
             "id":"20.5000.1025/KZL-VC0-ZK2",
             "attributes": {
-               "fdoProfile": "https://hdl.handle.net/21.T11148/64396cf36b976ad08267",
                "digitalObjectType": "https://hdl.handle.net/21.T11148/64396cf36b976ad08267",
                "subjectDigitalObjectId": "https://hdl.handle.net/20.5000.1025/DW0-BNT-FM0",
                "annotationTopic":"20.5000.1025/460-A7R-QMJ",

--- a/src/test/java/eu/dissco/annotationprocessingservice/web/TokenAuthenticatorTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/web/TokenAuthenticatorTest.java
@@ -109,11 +109,9 @@ class TokenAuthenticatorTest {
   }
 
   @Test
-  void testRetriesFailure() throws Exception {
+  void testRetriesFailure() {
     // Given
     int requestCount = mockTokenServer.getRequestCount();
-    var expectedJson = givenTokenResponse();
-    var expected = expectedJson.get("access_token").asText();
     given(properties.getFromFormData()).willReturn(testFromFormData);
     mockTokenServer.enqueue(new MockResponse().setResponseCode(501));
     mockTokenServer.enqueue(new MockResponse().setResponseCode(501));


### PR DESCRIPTION
- remove DigitalObjectType from attributes
- Use PID instead of name for Type in handle request