### PR TITLE
batchId minted after handles

### DIFF
--- a/src/main/java/eu/dissco/annotationprocessingservice/repository/ElasticSearchRepository.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/repository/ElasticSearchRepository.java
@@ -72,8 +72,13 @@ public class ElasticSearchRepository {
     for (var searchParam : bme.searchParams()) {
       var key = searchParam.inputField().replaceAll("\\[[^]]*]", "") + ".keyword";
       var val = searchParam.inputValue();
-      qList.add(
-          new Query.Builder().term(t -> t.field(key).value(val).caseInsensitive(true)).build());
+      if (val.isEmpty()) {
+        qList.add(
+            new Query.Builder().bool(b -> b.mustNot(q -> q.exists(e -> e.field(key)))).build());
+      } else {
+        qList.add(
+            new Query.Builder().term(t -> t.field(key).value(val).caseInsensitive(true)).build());
+      }
     }
     return qList;
   }

--- a/src/main/java/eu/dissco/annotationprocessingservice/service/AbstractProcessingService.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/service/AbstractProcessingService.java
@@ -55,11 +55,13 @@ public abstract class AbstractProcessingService {
     }
   }
 
-  protected void enrichNewAnnotation(Annotation annotation, String id, AnnotationEvent event,
-      Optional<Map<String, UUID>> batchIds) {
+  protected void enrichNewAnnotation(Annotation annotation, String id, AnnotationEvent event) {
     enrichNewAnnotation(annotation, id);
     annotation.setOdsJobId(applicationProperties.getHandleProxy() + event.jobId());
-    batchIds.ifPresentOrElse(idMap -> annotation.setOdsBatchId(idMap.get(id)),
+  }
+
+  protected void addBatchIds(Annotation annotation, Optional<Map<String, UUID>> batchIds, AnnotationEvent event){
+    batchIds.ifPresentOrElse(idMap -> annotation.setOdsBatchId(idMap.get(annotation.getOdsId())),
         () -> {
           if (event.batchId() != null) {
             annotation.setOdsBatchId(event.batchId());
@@ -139,6 +141,10 @@ public abstract class AbstractProcessingService {
   }
   protected void applyBatchAnnotations(AnnotationEvent event, List<Annotation> newAnnotations)
       throws BatchingException, ConflictException {
+    if (newAnnotations.isEmpty()) {
+      return;
+    }
+
     if (event.batchId() != null) { // This is a batchResult
       annotationBatchRecordService.updateAnnotationBatchRecord(event.batchId(),
           newAnnotations.size());

--- a/src/main/java/eu/dissco/annotationprocessingservice/service/AnnotationBatchRecordService.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/service/AnnotationBatchRecordService.java
@@ -2,6 +2,7 @@ package eu.dissco.annotationprocessingservice.service;
 
 import eu.dissco.annotationprocessingservice.domain.AnnotationBatchRecord;
 import eu.dissco.annotationprocessingservice.domain.AnnotationEvent;
+import eu.dissco.annotationprocessingservice.domain.HashedAnnotation;
 import eu.dissco.annotationprocessingservice.domain.annotation.Annotation;
 import eu.dissco.annotationprocessingservice.repository.AnnotationBatchRecordRepository;
 import java.time.Instant;
@@ -32,7 +33,13 @@ public class AnnotationBatchRecordService {
           value -> UUID.randomUUID()
       )));
       createNewAnnotationBatchRecord(batchIds.get(), newAnnotations);
-    } else {
+    } else if (event.batchId() != null) {
+      batchIds = Optional.of(newAnnotations.stream().collect(Collectors.toMap(
+          Annotation::getOdsId,
+          value -> event.batchId()
+      )));
+    }
+    else {
       batchIds = Optional.empty();
     }
     return batchIds;

--- a/src/main/resources/json-schema/annotation_request.json
+++ b/src/main/resources/json-schema/annotation_request.json
@@ -181,6 +181,9 @@
     },
     "placeInBatch": {
       "type": "number"
+    },
+    "ods:batchId": {
+      "type": "string"
     }
   },
   "required": [

--- a/src/test/java/eu/dissco/annotationprocessingservice/repository/ElasticSearchRepositoryIT.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/repository/ElasticSearchRepositoryIT.java
@@ -7,6 +7,7 @@ import static eu.dissco.annotationprocessingservice.TestUtils.MAPPER;
 import static eu.dissco.annotationprocessingservice.TestUtils.TARGET_ID;
 import static eu.dissco.annotationprocessingservice.TestUtils.givenAnnotationProcessed;
 import static eu.dissco.annotationprocessingservice.TestUtils.givenBatchMetadataExtendedTwoParam;
+import static eu.dissco.annotationprocessingservice.TestUtils.givenBatchMetadataSearchParamCountry;
 import static eu.dissco.annotationprocessingservice.TestUtils.givenElasticDocument;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -16,6 +17,8 @@ import co.elastic.clients.json.jackson.JacksonJsonpMapper;
 import co.elastic.clients.transport.ElasticsearchTransport;
 import co.elastic.clients.transport.rest_client.RestClientTransport;
 import com.fasterxml.jackson.databind.JsonNode;
+import eu.dissco.annotationprocessingservice.domain.BatchMetadataExtended;
+import eu.dissco.annotationprocessingservice.domain.BatchMetadataSearchParam;
 import eu.dissco.annotationprocessingservice.domain.annotation.AnnotationTargetType;
 import eu.dissco.annotationprocessingservice.properties.ElasticSearchProperties;
 import java.io.IOException;
@@ -165,6 +168,27 @@ class ElasticSearchRepositoryIT {
     var altDocument = givenElasticDocument("OtherCountry", ID_ALT);
     postDocuments(List.of(targetDocument, altDocument), DIGITAL_SPECIMEN_INDEX);
     var batchMetadata = givenBatchMetadataExtendedTwoParam();
+
+    // When
+    var result = repository.searchByBatchMetadataExtended(batchMetadata,
+        AnnotationTargetType.DIGITAL_SPECIMEN, 1, 10);
+
+    // Then
+    assertThat(result).isEqualTo(List.of(targetDocument));
+  }
+
+  @Test
+  void searchByBatchMetadataMustNotExist() throws Exception {
+    // Given
+    var targetDocument = givenElasticDocument("Netherlands", TARGET_ID);
+    var altDocument = givenElasticDocument("OtherCountry", ID_ALT);
+    postDocuments(List.of(targetDocument, altDocument), DIGITAL_SPECIMEN_INDEX);
+    var batchMetadata = new BatchMetadataExtended(1, List.of(
+        givenBatchMetadataSearchParamCountry(),
+        new BatchMetadataSearchParam(
+            "digitalSpecimenWrapper.thisFieldIsNotPresent",
+            ""
+        )));
 
     // When
     var result = repository.searchByBatchMetadataExtended(batchMetadata,

--- a/src/test/java/eu/dissco/annotationprocessingservice/service/AnnotationBatchRecordServiceTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/service/AnnotationBatchRecordServiceTest.java
@@ -20,6 +20,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -103,13 +104,14 @@ class AnnotationBatchRecordServiceTest {
   @Test
   void testMintBatchIdsIsBatchResult() {
     var annotations = List.of(givenAnnotationProcessed());
+    var expected = Map.of(ID, BATCH_ID);
 
     // When
     var result = service.mintBatchIds(annotations, true,
         new AnnotationEvent(annotations, JOB_ID, null, BATCH_ID));
 
     // Then
-    assertThat(result).isEmpty();
+    assertThat(result).contains(expected);
   }
 
   @Test

--- a/src/test/java/eu/dissco/annotationprocessingservice/service/ProcessingKafkaServiceTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/service/ProcessingKafkaServiceTest.java
@@ -273,9 +273,6 @@ class ProcessingKafkaServiceTest {
     given(annotationHasher.getAnnotationHash(any())).willReturn(ANNOTATION_HASH);
     given(repository.getAnnotationFromHash(Set.of(ANNOTATION_HASH))).willReturn(new ArrayList<>());
     given(handleComponent.postHandles(any())).willThrow(PidCreationException.class);
-    given(
-        annotationBatchRecordService.mintBatchIds(any(), eq(batchingRequested), any())).willReturn(
-        Optional.of(givenBatchIdMap()));
     given(masJobRecordService.getMasJobRecord(JOB_ID)).willReturn(
         new MasJobRecord(JOB_ID, batchingRequested, null));
 
@@ -283,8 +280,6 @@ class ProcessingKafkaServiceTest {
     assertThrows(FailedProcessingException.class,
         () -> service.handleMessage(givenAnnotationEvent()));
     then(masJobRecordService).should().markMasJobRecordAsFailed(JOB_ID, false);
-    then(annotationBatchRecordService).should()
-        .rollbackAnnotationBatchRecord(Optional.of(givenBatchIdMap()));
   }
 
   @Test
@@ -324,6 +319,7 @@ class ProcessingKafkaServiceTest {
     // Given
     boolean batchingRequested = true;
     var mjr = new MasJobRecord(JOB_ID, batchingRequested, null);
+    var event = givenAnnotationEvent();
     given(annotationHasher.getAnnotationHash(any())).willReturn(ANNOTATION_HASH);
     given(repository.getAnnotationFromHash(Set.of(ANNOTATION_HASH))).willReturn(new ArrayList<>());
     given(handleComponent.postHandles(any())).willReturn(Map.of(ANNOTATION_HASH, ID));
@@ -337,11 +333,11 @@ class ProcessingKafkaServiceTest {
         PROCESSOR_HANDLE);
     given(masJobRecordService.getMasJobRecord(JOB_ID)).willReturn(mjr);
     given(annotationBatchRecordService.mintBatchIds(anyList(), eq(batchingRequested),
-        eq(givenAnnotationEvent()))).willReturn(
+       eq(event))).willReturn(
         Optional.of(givenBatchIdMap()));
 
     // When
-    assertThatThrownBy(() -> service.handleMessage(givenAnnotationEvent())).isInstanceOf(
+    assertThatThrownBy(() -> service.handleMessage(event)).isInstanceOf(
         FailedProcessingException.class);
 
     // Then
@@ -397,8 +393,6 @@ class ProcessingKafkaServiceTest {
     given(repository.getAnnotationFromHash(any())).willReturn(List.of(givenHashedAnnotation()));
     given(masJobRecordService.getMasJobRecord(JOB_ID)).willReturn(
         new MasJobRecord(JOB_ID, batchingRequested, null));
-    given(annotationBatchRecordService.mintBatchIds(eq(Collections.emptyList()),
-        eq(batchingRequested), any())).willReturn(Optional.empty());
 
     // When
     service.handleMessage(givenAnnotationEvent(annotation));
@@ -425,8 +419,6 @@ class ProcessingKafkaServiceTest {
         List.of(givenRollbackCreationRequest()));
     given(masJobRecordService.getMasJobRecord(JOB_ID)).willReturn(
         new MasJobRecord(JOB_ID, batchingRequested, null));
-    given(annotationBatchRecordService.mintBatchIds(eq(Collections.emptyList()),
-        eq(batchingRequested), any())).willReturn(Optional.empty());
 
     // When
     service.handleMessage(givenAnnotationEvent(annotationRequest));
@@ -455,8 +447,6 @@ class ProcessingKafkaServiceTest {
     doThrow(PidCreationException.class).when(handleComponent).updateHandle(any());
     given(masJobRecordService.getMasJobRecord(JOB_ID)).willReturn(
         new MasJobRecord(JOB_ID, batchingRequested, null));
-    given(annotationBatchRecordService.mintBatchIds(eq(Collections.emptyList()),
-        eq(batchingRequested), any())).willReturn(Optional.empty());
 
     // Then
     assertThrows(FailedProcessingException.class,
@@ -733,7 +723,6 @@ class ProcessingKafkaServiceTest {
         List.of(givenRollbackCreationRequest()));
     given(masJobRecordService.getMasJobRecord(JOB_ID)).willReturn(
         new MasJobRecord(JOB_ID, batchingRequested, null));
-    given(annotationBatchRecordService.mintBatchIds(anyList(), eq(batchingRequested), any())).willReturn(Optional.empty());
 
     // When
     assertThatThrownBy(() -> service.handleMessage(givenAnnotationEvent(annotation))).isInstanceOf(
@@ -767,7 +756,6 @@ class ProcessingKafkaServiceTest {
         List.of(givenRollbackCreationRequest()));
     given(masJobRecordService.getMasJobRecord(JOB_ID)).willReturn(
         new MasJobRecord(JOB_ID, batchingRequested, null));
-    given(annotationBatchRecordService.mintBatchIds(anyList(), eq(batchingRequested), any())).willReturn(Optional.of(givenBatchIdMap()));
 
     // When
     assertThatThrownBy(() -> service.handleMessage(event)).isInstanceOf(
@@ -802,7 +790,6 @@ class ProcessingKafkaServiceTest {
     doThrow(PidCreationException.class).when(handleComponent).rollbackHandleUpdate(any());
     given(masJobRecordService.getMasJobRecord(JOB_ID)).willReturn(
         new MasJobRecord(JOB_ID, batchingRequested, null));
-    given(annotationBatchRecordService.mintBatchIds(anyList(), eq(batchingRequested), any())).willReturn(Optional.empty());
 
     // When
     assertThatThrownBy(
@@ -998,8 +985,6 @@ class ProcessingKafkaServiceTest {
     doThrow(DataAccessException.class).when(repository).createAnnotationRecord(anyList());
     given(masJobRecordService.getMasJobRecord(JOB_ID)).willReturn(
         new MasJobRecord(JOB_ID, batchingRequested, null));
-    given(annotationBatchRecordService.mintBatchIds(anyList(), eq(batchingRequested),
-        any())).willReturn(Optional.empty());
 
     // When
     assertThrows(FailedProcessingException.class,


### PR DESCRIPTION
Bug fixes :lady_beetle: 
- Searching Add "must not exist" query if field is blank in elastic
- Mints batch ids after handles are minted
- Don't apply batching if there are no new annotations (updates are coming! but not in this pr)