### PR TITLE
Add kafka topic for auto-accepted messages

### DIFF
--- a/src/main/java/eu/dissco/annotationprocessingservice/domain/AutoAcceptedAnnotation.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/domain/AutoAcceptedAnnotation.java
@@ -1,0 +1,11 @@
+package eu.dissco.annotationprocessingservice.domain;
+
+import eu.dissco.annotationprocessingservice.schema.Agent;
+import eu.dissco.annotationprocessingservice.schema.AnnotationProcessingRequest;
+
+public record AutoAcceptedAnnotation(
+    Agent acceptingAgent,
+    AnnotationProcessingRequest annotation
+) {
+
+}

--- a/src/main/java/eu/dissco/annotationprocessingservice/service/KafkaConsumerService.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/service/KafkaConsumerService.java
@@ -2,12 +2,13 @@ package eu.dissco.annotationprocessingservice.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.annotationprocessingservice.Profiles;
-import eu.dissco.annotationprocessingservice.schema.AnnotationProcessingEvent;
+import eu.dissco.annotationprocessingservice.domain.AutoAcceptedAnnotation;
 import eu.dissco.annotationprocessingservice.exception.AnnotationValidationException;
 import eu.dissco.annotationprocessingservice.exception.BatchingException;
 import eu.dissco.annotationprocessingservice.exception.ConflictException;
 import eu.dissco.annotationprocessingservice.exception.DataBaseException;
 import eu.dissco.annotationprocessingservice.exception.FailedProcessingException;
+import eu.dissco.annotationprocessingservice.schema.AnnotationProcessingEvent;
 import java.io.IOException;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,12 +25,20 @@ public class KafkaConsumerService {
 
   private final ObjectMapper mapper;
   private final ProcessingKafkaService service;
+  private final ProcessingAutoAcceptedService autoAcceptedService;
 
   @KafkaListener(topics = "${kafka.consumer.topic}")
   public void getMessages(@Payload String message)
       throws IOException, DataBaseException, FailedProcessingException, AnnotationValidationException, ConflictException, BatchingException {
     var event = mapper.readValue(message, AnnotationProcessingEvent.class);
     service.handleMessage(event);
+  }
+
+  @KafkaListener(topics = "${kafka.consumer.topic.auto-accepted}")
+  public void getAutoAcceptedMessages(@Payload String message)
+      throws IOException, DataBaseException, FailedProcessingException {
+    var event = mapper.readValue(message, AutoAcceptedAnnotation.class);
+    autoAcceptedService.handleMessage(event);
   }
 
 }

--- a/src/main/java/eu/dissco/annotationprocessingservice/service/ProcessingAutoAcceptedService.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/service/ProcessingAutoAcceptedService.java
@@ -1,0 +1,66 @@
+package eu.dissco.annotationprocessingservice.service;
+
+import static eu.dissco.annotationprocessingservice.configuration.ApplicationConfiguration.HANDLE_PROXY;
+
+import eu.dissco.annotationprocessingservice.Profiles;
+import eu.dissco.annotationprocessingservice.component.SchemaValidatorComponent;
+import eu.dissco.annotationprocessingservice.domain.AutoAcceptedAnnotation;
+import eu.dissco.annotationprocessingservice.exception.FailedProcessingException;
+import eu.dissco.annotationprocessingservice.properties.ApplicationProperties;
+import eu.dissco.annotationprocessingservice.repository.AnnotationRepository;
+import eu.dissco.annotationprocessingservice.repository.ElasticSearchRepository;
+import eu.dissco.annotationprocessingservice.schema.Annotation;
+import eu.dissco.annotationprocessingservice.schema.Annotation.OdsMergingDecisionStatus;
+import eu.dissco.annotationprocessingservice.web.HandleComponent;
+import java.time.Instant;
+import java.util.Date;
+import lombok.extern.slf4j.Slf4j;
+import org.jooq.exception.DataAccessException;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@Profile(Profiles.KAFKA)
+public class ProcessingAutoAcceptedService extends AbstractProcessingService {
+
+  public ProcessingAutoAcceptedService(
+      AnnotationRepository repository,
+      ElasticSearchRepository elasticRepository,
+      KafkaPublisherService kafkaService, FdoRecordService fdoRecordService,
+      HandleComponent handleComponent,
+      ApplicationProperties applicationProperties,
+      SchemaValidatorComponent schemaValidator,
+      MasJobRecordService masJobRecordService, BatchAnnotationService batchAnnotationService,
+      AnnotationBatchRecordService annotationBatchRecordService) {
+    super(repository, elasticRepository, kafkaService, fdoRecordService, handleComponent,
+        applicationProperties, schemaValidator, masJobRecordService, batchAnnotationService,
+        annotationBatchRecordService);
+  }
+
+  private static void addMergingInformation(AutoAcceptedAnnotation autoAcceptedAnnotation,
+      Annotation annotation) {
+    annotation.setOdsMergingDecisionStatus(OdsMergingDecisionStatus.ODS_APPROVED);
+    annotation.setOdsMergingStateChangeDate(Date.from(Instant.now()));
+    annotation.setOdsMergingStateChangedBy(autoAcceptedAnnotation.acceptingAgent());
+  }
+
+  public void handleMessage(AutoAcceptedAnnotation autoAcceptedAnnotation)
+      throws FailedProcessingException {
+    log.info("Processing auto-accepted annotation: {}", autoAcceptedAnnotation);
+    var id = postHandle(autoAcceptedAnnotation.annotation());
+    var annotation = buildAnnotation(autoAcceptedAnnotation.annotation(), HANDLE_PROXY + id, 1, null);
+    addMergingInformation(autoAcceptedAnnotation, annotation);
+    log.info("New id has been generated for Annotation: {}", annotation.getId());
+    try {
+      repository.createAnnotationRecord(annotation);
+    } catch (DataAccessException e) {
+      log.error("Unable to post new Annotation to DB", e);
+      rollbackHandleCreation(annotation);
+      throw new FailedProcessingException();
+    }
+    log.info("Annotation: {} has been successfully committed to database", id);
+    indexElasticNewAnnotation(annotation, id);
+  }
+
+}

--- a/src/main/java/eu/dissco/annotationprocessingservice/service/ProcessingKafkaService.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/service/ProcessingKafkaService.java
@@ -10,7 +10,6 @@ import eu.dissco.annotationprocessingservice.Profiles;
 import eu.dissco.annotationprocessingservice.component.AnnotationHasher;
 import eu.dissco.annotationprocessingservice.component.SchemaValidatorComponent;
 import eu.dissco.annotationprocessingservice.database.jooq.enums.ErrorCode;
-import eu.dissco.annotationprocessingservice.schema.AnnotationProcessingEvent;
 import eu.dissco.annotationprocessingservice.domain.HashedAnnotation;
 import eu.dissco.annotationprocessingservice.domain.HashedAnnotationRequest;
 import eu.dissco.annotationprocessingservice.domain.ProcessResult;
@@ -25,6 +24,7 @@ import eu.dissco.annotationprocessingservice.properties.ApplicationProperties;
 import eu.dissco.annotationprocessingservice.repository.AnnotationRepository;
 import eu.dissco.annotationprocessingservice.repository.ElasticSearchRepository;
 import eu.dissco.annotationprocessingservice.schema.Annotation;
+import eu.dissco.annotationprocessingservice.schema.AnnotationProcessingEvent;
 import eu.dissco.annotationprocessingservice.schema.AnnotationProcessingRequest;
 import eu.dissco.annotationprocessingservice.web.HandleComponent;
 import java.io.IOException;
@@ -84,7 +84,8 @@ public class ProcessingKafkaService extends AbstractProcessingService {
       var masJobRecord = masJobRecordService.getMasJobRecord(event.getJobId());
       var processResult = processAnnotations(event);
       var equalIds = processEqualAnnotations(processResult.equalAnnotations());
-      var updatedIds = updateExistingAnnotations(processResult.changedAnnotations(), event.getJobId(),
+      var updatedIds = updateExistingAnnotations(processResult.changedAnnotations(),
+          event.getJobId(),
           isBatchResult);
       var newAnnotations = persistNewAnnotation(processResult.newAnnotations(), event.getJobId(),
           isBatchResult, masJobRecord.batchingRequested(), event);
@@ -141,8 +142,7 @@ public class ProcessingKafkaService extends AbstractProcessingService {
 
   private List<Annotation> persistNewAnnotation(
       List<HashedAnnotationRequest> hashedAnnotationsRequest, String jobId,
-      boolean isBatchResult,
-      boolean batchingRequested, AnnotationProcessingEvent event)
+      boolean isBatchResult, boolean batchingRequested, AnnotationProcessingEvent event)
       throws FailedProcessingException {
     if (hashedAnnotationsRequest.isEmpty()) {
       return Collections.emptyList();
@@ -193,8 +193,7 @@ public class ProcessingKafkaService extends AbstractProcessingService {
   }
 
   private List<String> updateExistingAnnotations(Set<UpdatedAnnotation> updatedAnnotations,
-      String jobId, boolean isBatchResult)
-      throws FailedProcessingException {
+      String jobId, boolean isBatchResult) throws FailedProcessingException {
     if (updatedAnnotations.isEmpty()) {
       return Collections.emptyList();
     }

--- a/src/test/java/eu/dissco/annotationprocessingservice/TestUtils.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/TestUtils.java
@@ -9,6 +9,8 @@ import eu.dissco.annotationprocessingservice.configuration.DateDeserializer;
 import eu.dissco.annotationprocessingservice.configuration.DateSerializer;
 import eu.dissco.annotationprocessingservice.configuration.InstantDeserializer;
 import eu.dissco.annotationprocessingservice.configuration.InstantSerializer;
+import eu.dissco.annotationprocessingservice.domain.AutoAcceptedAnnotation;
+import eu.dissco.annotationprocessingservice.schema.Annotation.OdsMergingDecisionStatus;
 import eu.dissco.annotationprocessingservice.schema.AnnotationBatchMetadata;
 import eu.dissco.annotationprocessingservice.schema.AnnotationBody;
 import eu.dissco.annotationprocessingservice.schema.AnnotationProcessingEvent;
@@ -434,6 +436,25 @@ public class TestUtils {
     return new ProcessedAnnotationBatch(List.of(givenBaseAnnotationForBatch(1, ID, BATCH_ID)
         .withOdsPlaceInBatch(1)), JOB_ID,
         List.of(givenAnnotationBatchMetadataLatitudeSearch()), null);
+  }
+
+  public static Annotation givenAcceptedAnnotation() {
+    var annotation = givenAnnotationProcessedWeb();
+    annotation.setOdsMergingStateChangeDate(Date.from(CREATED));
+    annotation.setOdsMergingDecisionStatus(OdsMergingDecisionStatus.ODS_APPROVED);
+    annotation.setOdsMergingStateChangedBy(givenProcessingAgent());
+    return annotation;
+  }
+
+  public static AutoAcceptedAnnotation givenAutoAcceptedRequest() {
+    return new AutoAcceptedAnnotation(givenProcessingAgent(), givenAnnotationRequest());
+  }
+
+  public static Agent givenProcessingAgent() {
+    return new Agent()
+        .withType(Type.AS_APPLICATION)
+        .withId(ID)
+        .withSchemaName("A processing service");
   }
 
   public static JsonNode givenElasticDocument() {

--- a/src/test/java/eu/dissco/annotationprocessingservice/service/KafkaConsumerServiceTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/service/KafkaConsumerServiceTest.java
@@ -2,10 +2,14 @@ package eu.dissco.annotationprocessingservice.service;
 
 import static eu.dissco.annotationprocessingservice.TestUtils.JOB_ID;
 import static eu.dissco.annotationprocessingservice.TestUtils.MAPPER;
+import static eu.dissco.annotationprocessingservice.TestUtils.givenAcceptedAnnotation;
 import static eu.dissco.annotationprocessingservice.TestUtils.givenAnnotationEvent;
 import static eu.dissco.annotationprocessingservice.TestUtils.givenAnnotationRequest;
+import static eu.dissco.annotationprocessingservice.TestUtils.givenAutoAcceptedRequest;
 import static org.mockito.BDDMockito.then;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import eu.dissco.annotationprocessingservice.domain.AutoAcceptedAnnotation;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -18,12 +22,14 @@ class KafkaConsumerServiceTest {
 
   @Mock
   private ProcessingKafkaService processingKafkaService;
+  @Mock
+  private ProcessingAutoAcceptedService autoAcceptedService;
 
   private KafkaConsumerService service;
 
   @BeforeEach
   void setup() {
-    service = new KafkaConsumerService(MAPPER, processingKafkaService);
+    service = new KafkaConsumerService(MAPPER, processingKafkaService, autoAcceptedService);
   }
 
   @Test
@@ -36,6 +42,22 @@ class KafkaConsumerServiceTest {
 
     // Then
     then(processingKafkaService).should().handleMessage(givenAnnotationEvent());
+  }
+
+  @Test
+  void testGetAutoAcceptedMessages() throws Exception {
+    // Given
+    var message = givenAutoAcceptedMessage();
+
+    // When
+    service.getAutoAcceptedMessages(message);
+
+    // Then
+    then(autoAcceptedService).should().handleMessage(givenAutoAcceptedRequest());
+  }
+
+  private String givenAutoAcceptedMessage() throws JsonProcessingException {
+    return MAPPER.writeValueAsString(givenAutoAcceptedRequest());
   }
 
   private String givenMessage() throws Exception {

--- a/src/test/java/eu/dissco/annotationprocessingservice/service/ProcessingAutoAcceptedServiceTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/service/ProcessingAutoAcceptedServiceTest.java
@@ -1,0 +1,228 @@
+package eu.dissco.annotationprocessingservice.service;
+
+import static eu.dissco.annotationprocessingservice.TestUtils.BARE_ID;
+import static eu.dissco.annotationprocessingservice.TestUtils.CREATED;
+import static eu.dissco.annotationprocessingservice.TestUtils.ID;
+import static eu.dissco.annotationprocessingservice.TestUtils.givenAcceptedAnnotation;
+import static eu.dissco.annotationprocessingservice.TestUtils.givenAutoAcceptedRequest;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+
+import co.elastic.clients.elasticsearch._types.Result;
+import co.elastic.clients.elasticsearch.core.IndexResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import eu.dissco.annotationprocessingservice.component.SchemaValidatorComponent;
+import eu.dissco.annotationprocessingservice.exception.FailedProcessingException;
+import eu.dissco.annotationprocessingservice.exception.PidCreationException;
+import eu.dissco.annotationprocessingservice.properties.ApplicationProperties;
+import eu.dissco.annotationprocessingservice.repository.AnnotationRepository;
+import eu.dissco.annotationprocessingservice.repository.ElasticSearchRepository;
+import eu.dissco.annotationprocessingservice.schema.Annotation;
+import eu.dissco.annotationprocessingservice.web.HandleComponent;
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import org.jooq.exception.DataAccessException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProcessingAutoAcceptedServiceTest {
+
+  private final Instant instant = Instant.now(Clock.fixed(CREATED, ZoneOffset.UTC));
+  Clock clock = Clock.fixed(CREATED, ZoneOffset.UTC);
+  MockedStatic<Clock> mockedClock = mockStatic(Clock.class);
+  @Mock
+  private AnnotationRepository repository;
+  @Mock
+  private ElasticSearchRepository elasticRepository;
+  @Mock
+  private KafkaPublisherService kafkaPublisherService;
+  @Mock
+  private FdoRecordService fdoRecordService;
+  @Mock
+  private HandleComponent handleComponent;
+  @Mock
+  private ApplicationProperties applicationProperties;
+  @Mock
+  private SchemaValidatorComponent schemaValidator;
+  @Mock
+  private MasJobRecordService masJobRecordService;
+  @Mock
+  private BatchAnnotationService batchAnnotationService;
+  @Mock
+  private AnnotationBatchRecordService annotationBatchRecordService;
+  private MockedStatic<Instant> mockedStatic;
+  private ProcessingAutoAcceptedService service;
+
+  @BeforeEach
+  void setup() {
+    service = new ProcessingAutoAcceptedService(repository, elasticRepository,
+        kafkaPublisherService, fdoRecordService, handleComponent, applicationProperties,
+        schemaValidator, masJobRecordService, batchAnnotationService, annotationBatchRecordService);
+    mockedStatic = mockStatic(Instant.class);
+    mockedStatic.when(Instant::now).thenReturn(instant);
+    mockedClock.when(Clock::systemUTC).thenReturn(clock);
+  }
+
+  @AfterEach
+  void destroy() {
+    mockedStatic.close();
+    mockedClock.close();
+  }
+
+  @Test
+  void testCreateAnnotation() throws Exception {
+    // Given
+    var annotationRequest = givenAutoAcceptedRequest();
+    given(handleComponent.postHandle(any())).willReturn(List.of(BARE_ID));
+    var indexResponse = mock(IndexResponse.class);
+    given(indexResponse.result()).willReturn(Result.Created);
+    given(elasticRepository.indexAnnotation(any(Annotation.class))).willReturn(indexResponse);
+    given(applicationProperties.getProcessorHandle()).willReturn(
+        "https://hdl.handle.net/anno-process-service-pid");
+
+    // When
+    service.handleMessage(annotationRequest);
+
+    // Then
+    then(repository).should().createAnnotationRecord(givenAcceptedAnnotation());
+    then(kafkaPublisherService).should().publishCreateEvent(any(Annotation.class));
+  }
+
+  @Test
+  void testDataAccessExceptionNewAnnotation() throws Exception {
+    var annotationRequest = givenAutoAcceptedRequest();
+    given(handleComponent.postHandle(any())).willReturn(List.of(ID));
+    given(applicationProperties.getProcessorHandle()).willReturn(
+        "https://hdl.handle.net/anno-process-service-pid");
+    doThrow(DataAccessException.class).when(repository)
+        .createAnnotationRecord(any(Annotation.class));
+
+    // When / Then
+    assertThrows(FailedProcessingException.class,
+        () -> service.handleMessage(annotationRequest));
+    then(handleComponent).should().rollbackHandleCreation(any());
+  }
+
+  @Test
+  void testCreateAnnotationElasticIOException() throws Exception {
+    // Given
+    var annotationRequest = givenAutoAcceptedRequest();
+    given(handleComponent.postHandle(any())).willReturn(List.of(BARE_ID));
+    doThrow(IOException.class).when(elasticRepository).indexAnnotation(any(Annotation.class));
+    given(applicationProperties.getProcessorHandle()).willReturn(
+        "https://hdl.handle.net/anno-process-service-pid");
+
+    // When
+    assertThrows(FailedProcessingException.class,
+        () -> service.handleMessage(annotationRequest));
+
+    // Then
+    then(repository).should().rollbackAnnotation(ID);
+    then(fdoRecordService).should().buildRollbackCreationRequest(givenAcceptedAnnotation());
+    then(handleComponent).should().rollbackHandleCreation(any());
+    then(kafkaPublisherService).shouldHaveNoInteractions();
+  }
+
+  @Test
+  void testCreateAnnotationElasticFailure() throws Exception {
+    // Given
+    var annotationRequest = givenAutoAcceptedRequest();
+    given(handleComponent.postHandle(any())).willReturn(List.of(BARE_ID));
+    given(applicationProperties.getProcessorHandle()).willReturn(
+        "https://hdl.handle.net/anno-process-service-pid");
+    var indexResponse = mock(IndexResponse.class);
+    given(indexResponse.result()).willReturn(Result.NotFound);
+    given(elasticRepository.indexAnnotation(givenAcceptedAnnotation())).willReturn(
+        indexResponse);
+    given(applicationProperties.getProcessorHandle()).willReturn(
+        "https://hdl.handle.net/anno-process-service-pid");
+
+    // When
+    assertThrows(FailedProcessingException.class, () -> service.handleMessage(annotationRequest));
+
+    // Then
+    then(repository).should().rollbackAnnotation(ID);
+    then(fdoRecordService).should().buildRollbackCreationRequest(givenAcceptedAnnotation());
+    then(handleComponent).should().rollbackHandleCreation(any());
+    then(kafkaPublisherService).shouldHaveNoInteractions();
+  }
+
+  @Test
+  void testCreateAnnotationElasticFailureNoArchive() throws Exception {
+    // Given
+    var annotationRequest = givenAutoAcceptedRequest();
+    given(handleComponent.postHandle(any())).willReturn(List.of(BARE_ID));
+    given(applicationProperties.getProcessorHandle()).willReturn(
+        "https://hdl.handle.net/anno-process-service-pid");
+    var indexResponse = mock(IndexResponse.class);
+    given(indexResponse.result()).willReturn(Result.NotFound);
+    given(elasticRepository.indexAnnotation(givenAcceptedAnnotation())).willReturn(
+        indexResponse);
+    doThrow(PidCreationException.class).when(handleComponent).rollbackHandleCreation(any());
+    given(applicationProperties.getProcessorHandle()).willReturn(
+        "https://hdl.handle.net/anno-process-service-pid");
+
+    // When
+    assertThrows(FailedProcessingException.class, () -> service.handleMessage(annotationRequest));
+
+    // Then
+    then(repository).should().rollbackAnnotation(ID);
+    then(fdoRecordService).should().buildRollbackCreationRequest(givenAcceptedAnnotation());
+    then(handleComponent).should().rollbackHandleCreation(any());
+    then(kafkaPublisherService).shouldHaveNoInteractions();
+  }
+
+  @Test
+  void testCreateAnnotationKafkaFailure() throws Exception {
+    // Given
+    var annotationRequest = givenAutoAcceptedRequest();
+    given(handleComponent.postHandle(any())).willReturn(List.of(BARE_ID));
+    var indexResponse = mock(IndexResponse.class);
+    given(indexResponse.result()).willReturn(Result.Created);
+    given(elasticRepository.indexAnnotation(any(Annotation.class))).willReturn(indexResponse);
+    given(applicationProperties.getProcessorHandle()).willReturn(
+        "https://hdl.handle.net/anno-process-service-pid");
+    doThrow(JsonProcessingException.class).when(kafkaPublisherService)
+        .publishCreateEvent(givenAcceptedAnnotation());
+
+    // When
+    assertThrows(FailedProcessingException.class, () -> service.handleMessage(annotationRequest));
+
+    // Then
+    then(repository).should().rollbackAnnotation(ID);
+    then(elasticRepository).should().archiveAnnotation(ID);
+    then(fdoRecordService).should().buildRollbackCreationRequest(givenAcceptedAnnotation());
+    then(handleComponent).should().rollbackHandleCreation(any());
+    then(kafkaPublisherService).shouldHaveNoMoreInteractions();
+  }
+
+  @Test
+  void testCreateAnnotationPidFailure() throws Exception {
+    // Given
+    var annotationRequest = givenAutoAcceptedRequest();
+    doThrow(PidCreationException.class).when(handleComponent).postHandle(any());
+
+    // When
+    assertThrows(FailedProcessingException.class, () -> service.handleMessage(annotationRequest));
+
+    // Then
+    then(repository).shouldHaveNoInteractions();
+    then(elasticRepository).shouldHaveNoInteractions();
+    then(kafkaPublisherService).shouldHaveNoInteractions();
+  }
+
+}


### PR DESCRIPTION
- New kafka endpoint for auto-accepted messages coming from digital specimen/media processors (kept existing endpoint the same)
- Moved generic functionality to parent class

https://naturalis.atlassian.net/browse/DD-1325