### PR TITLE
Feature/tombstone annotation metadata

### DIFF
--- a/src/main/java/eu/dissco/annotationprocessingservice/controller/AnnotationController.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/controller/AnnotationController.java
@@ -3,6 +3,7 @@ package eu.dissco.annotationprocessingservice.controller;
 import static eu.dissco.annotationprocessingservice.configuration.ApplicationConfiguration.HANDLE_PROXY;
 
 import eu.dissco.annotationprocessingservice.Profiles;
+import eu.dissco.annotationprocessingservice.domain.AnnotationTombstoneWrapper;
 import eu.dissco.annotationprocessingservice.schema.Agent;
 import eu.dissco.annotationprocessingservice.schema.AnnotationProcessingEvent;
 import eu.dissco.annotationprocessingservice.exception.AnnotationValidationException;
@@ -66,15 +67,17 @@ public class AnnotationController {
   }
 
   @DeleteMapping(value = "/{prefix}/{suffix}")
-  public ResponseEntity<Void> archiveAnnotation(@PathVariable("prefix") String prefix,
-      @PathVariable("suffix") String suffix, Annotation annotation, Agent deletingAgent) throws IOException, FailedProcessingException {
+  public ResponseEntity<Void> tombstoneAnnotation(@PathVariable("prefix") String prefix,
+      @PathVariable("suffix") String suffix, @RequestBody AnnotationTombstoneWrapper annotationTombstoneWrapper) throws IOException, FailedProcessingException {
     var id = prefix + '/' + suffix;
     log.info("Received an archive request for annotations: {}", id);
+    var annotation = annotationTombstoneWrapper.annotation();
+    var tombstoningAgent = annotationTombstoneWrapper.tombstoningAgent();
     if (!annotation.getId().contains(id)){
       log.error("Id in path {} does not match id in annotation {}", id, annotation.getId());
       throw new FailedProcessingException();
     }
-    processingService.archiveAnnotation(annotation, deletingAgent);
+    processingService.archiveAnnotation(annotation, tombstoningAgent);
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 

--- a/src/main/java/eu/dissco/annotationprocessingservice/controller/AnnotationController.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/controller/AnnotationController.java
@@ -3,6 +3,7 @@ package eu.dissco.annotationprocessingservice.controller;
 import static eu.dissco.annotationprocessingservice.configuration.ApplicationConfiguration.HANDLE_PROXY;
 
 import eu.dissco.annotationprocessingservice.Profiles;
+import eu.dissco.annotationprocessingservice.schema.Agent;
 import eu.dissco.annotationprocessingservice.schema.AnnotationProcessingEvent;
 import eu.dissco.annotationprocessingservice.exception.AnnotationValidationException;
 import eu.dissco.annotationprocessingservice.exception.ConflictException;
@@ -64,12 +65,16 @@ public class AnnotationController {
     return ResponseEntity.ok(result);
   }
 
-  @DeleteMapping(value = "/{prefix}/{postfix}")
+  @DeleteMapping(value = "/{prefix}/{suffix}")
   public ResponseEntity<Void> archiveAnnotation(@PathVariable("prefix") String prefix,
-      @PathVariable("postfix") String postfix) throws IOException, FailedProcessingException {
-    var id = prefix + '/' + postfix;
+      @PathVariable("suffix") String suffix, Annotation annotation, Agent deletingAgent) throws IOException, FailedProcessingException {
+    var id = prefix + '/' + suffix;
     log.info("Received an archive request for annotations: {}", id);
-    processingService.archiveAnnotation(id);
+    if (!annotation.getId().contains(id)){
+      log.error("Id in path {} does not match id in annotation {}", id, annotation.getId());
+      throw new FailedProcessingException();
+    }
+    processingService.archiveAnnotation(annotation, deletingAgent);
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 

--- a/src/main/java/eu/dissco/annotationprocessingservice/domain/AnnotationTombstoneWrapper.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/domain/AnnotationTombstoneWrapper.java
@@ -1,0 +1,11 @@
+package eu.dissco.annotationprocessingservice.domain;
+
+import eu.dissco.annotationprocessingservice.schema.Agent;
+import eu.dissco.annotationprocessingservice.schema.Annotation;
+
+public record AnnotationTombstoneWrapper (
+    Annotation annotation,
+    Agent tombstoningAgent
+){
+
+}

--- a/src/main/java/eu/dissco/annotationprocessingservice/repository/AnnotationRepository.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/repository/AnnotationRepository.java
@@ -147,9 +147,9 @@ public class AnnotationRepository {
         .fetchOptional(Record1::value1);
   }
 
-  public void archiveAnnotation(Annotation annotation) throws FailedProcessingException {
+  public void archiveAnnotation(Annotation annotation, Instant timestamp) throws FailedProcessingException {
     context.update(ANNOTATION)
-        .set(ANNOTATION.TOMBSTONED_ON, Instant.now())
+        .set(ANNOTATION.TOMBSTONED_ON, timestamp)
         .set(ANNOTATION.DATA, mapToJSONB(annotation))
         .where(ANNOTATION.ID.eq(annotation.getId().replace(HANDLE_PROXY, "")))
         .execute();

--- a/src/main/java/eu/dissco/annotationprocessingservice/repository/AnnotationRepository.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/repository/AnnotationRepository.java
@@ -150,6 +150,8 @@ public class AnnotationRepository {
   public void archiveAnnotation(Annotation annotation, Instant timestamp) throws FailedProcessingException {
     context.update(ANNOTATION)
         .set(ANNOTATION.TOMBSTONED_ON, timestamp)
+        .set(ANNOTATION.MODIFIED, timestamp)
+        .set(ANNOTATION.LAST_CHECKED, timestamp)
         .set(ANNOTATION.DATA, mapToJSONB(annotation))
         .where(ANNOTATION.ID.eq(annotation.getId().replace(HANDLE_PROXY, "")))
         .execute();

--- a/src/main/java/eu/dissco/annotationprocessingservice/repository/AnnotationRepository.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/repository/AnnotationRepository.java
@@ -153,6 +153,7 @@ public class AnnotationRepository {
         .set(ANNOTATION.MODIFIED, timestamp)
         .set(ANNOTATION.LAST_CHECKED, timestamp)
         .set(ANNOTATION.DATA, mapToJSONB(annotation))
+        .set(ANNOTATION.VERSION, annotation.getOdsVersion())
         .where(ANNOTATION.ID.eq(annotation.getId().replace(HANDLE_PROXY, "")))
         .execute();
   }

--- a/src/main/java/eu/dissco/annotationprocessingservice/service/AbstractProcessingService.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/service/AbstractProcessingService.java
@@ -19,7 +19,6 @@ import eu.dissco.annotationprocessingservice.schema.Agent;
 import eu.dissco.annotationprocessingservice.schema.Agent.Type;
 import eu.dissco.annotationprocessingservice.schema.Annotation;
 import eu.dissco.annotationprocessingservice.schema.Annotation.OaMotivation;
-import eu.dissco.annotationprocessingservice.schema.Annotation.OdsMergingDecisionStatus;
 import eu.dissco.annotationprocessingservice.schema.Annotation.OdsStatus;
 import eu.dissco.annotationprocessingservice.schema.AnnotationProcessingEvent;
 import eu.dissco.annotationprocessingservice.schema.AnnotationProcessingRequest;
@@ -140,9 +139,9 @@ public abstract class AbstractProcessingService {
   public void archiveAnnotation(Annotation currentAnnotation, Agent tombstoningAgent)
       throws IOException, FailedProcessingException {
     log.info("Archive annotations: {} in handle service", currentAnnotation.getId());
-    var requestBody = fdoRecordService.buildArchiveHandleRequest(currentAnnotation.getId());
+    var requestBody = fdoRecordService.buildTombstoneHandleRequest(currentAnnotation.getId().replace(HANDLE_PROXY, ""));
     try {
-      handleComponent.archiveHandle(requestBody, currentAnnotation.getId());
+      handleComponent.archiveHandle(requestBody, (currentAnnotation.getId().replace(HANDLE_PROXY, "")));
     } catch (PidCreationException e) {
       log.error("Unable to archive annotations in handle system for annotations {}",
           currentAnnotation.getId(), e);

--- a/src/main/java/eu/dissco/annotationprocessingservice/service/AbstractProcessingService.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/service/AbstractProcessingService.java
@@ -154,7 +154,7 @@ public abstract class AbstractProcessingService {
       log.info("Archive annotations: {} in database", currentAnnotation.getId());
       var timestamp = Instant.now();
       var tombstoneAnnotation = buildTombstoneAnnotation(currentAnnotation, tombstoningAgent, timestamp);
-      repository.archiveAnnotation(tombstoneAnnotation, timestamp);
+      repository.archiveAnnotation(tombstoneAnnotation);
       log.info("Sending Tombstone event to provenance servie");
       kafkaService.publishTombstoneEvent(tombstoneAnnotation, currentAnnotation);
       log.info("Archived annotations: {}", currentAnnotation.getId());
@@ -185,9 +185,6 @@ public abstract class AbstractProcessingService {
         .withSchemaAggregateRating(annotation.getSchemaAggregateRating())
         .withOdsBatchID(annotation.getOdsBatchID())
         .withOdsPlaceInBatch(annotation.getOdsPlaceInBatch())
-        .withOdsMergingDecisionStatus(OdsMergingDecisionStatus.ODS_REJECTED)
-        .withOdsMergingStateChangeDate(Date.from(timestamp))
-        .withOdsMergingStateChangedBy(tombstoningAgent)
         .withOdsTombstoneMetadata(new TombstoneMetadata()
             .withType("ods:Tombstone")
             .withOdsTombstoneDate(Date.from(timestamp))

--- a/src/main/java/eu/dissco/annotationprocessingservice/service/FdoRecordService.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/service/FdoRecordService.java
@@ -87,8 +87,8 @@ public class FdoRecordService {
   public JsonNode buildArchiveHandleRequest(String id) {
     var request = mapper.createObjectNode();
     var data = mapper.createObjectNode();
-    var attributes = mapper.createObjectNode();
-    attributes.put("tombstoneText", "This annotation was archived");
+    var attributes = mapper.createObjectNode()
+        .put("tombstoneText", "This annotation was archived");
     data.put(ID, id);
     data.set(ATTRIBUTES, attributes);
     request.set(DATA, data);

--- a/src/main/java/eu/dissco/annotationprocessingservice/service/FdoRecordService.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/service/FdoRecordService.java
@@ -84,7 +84,7 @@ public class FdoRecordService {
     return request;
   }
 
-  public JsonNode buildArchiveHandleRequest(String id) {
+  public JsonNode buildTombstoneHandleRequest(String id) {
     var request = mapper.createObjectNode();
     var data = mapper.createObjectNode();
     var attributes = mapper.createObjectNode()

--- a/src/main/java/eu/dissco/annotationprocessingservice/service/KafkaPublisherService.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/service/KafkaPublisherService.java
@@ -17,20 +17,28 @@ public class KafkaPublisherService {
   private final KafkaTemplate<String, String> kafkaTemplate;
   private final KafkaConsumerProperties consumerProperties;
   private final ProvenanceService provenanceService;
+  private static final String TOPIC = "createUpdateDeleteTopic";
 
   public void publishCreateEvent(Annotation annotation) throws JsonProcessingException {
     var event = provenanceService.generateCreateEvent(annotation);
-    kafkaTemplate.send("createUpdateDeleteTopic", mapper.writeValueAsString(event));
+    kafkaTemplate.send(TOPIC, mapper.writeValueAsString(event));
   }
 
   public void publishUpdateEvent(Annotation currentAnnotation, Annotation annotation)
       throws JsonProcessingException {
     var event = provenanceService.generateUpdateEvent(annotation, currentAnnotation);
-    kafkaTemplate.send("createUpdateDeleteTopic", mapper.writeValueAsString(event));
+    kafkaTemplate.send(TOPIC, mapper.writeValueAsString(event));
   }
 
   public void publishBatchAnnotation(ProcessedAnnotationBatch annotationEvent)
       throws JsonProcessingException {
-      kafkaTemplate.send(consumerProperties.getTopic(), mapper.writeValueAsString(annotationEvent));
+    kafkaTemplate.send(consumerProperties.getTopic(), mapper.writeValueAsString(annotationEvent));
   }
+
+  public void publishTombstoneEvent(Annotation tombstoneAnnotation, Annotation currentAnnotation)
+      throws JsonProcessingException {
+    var event = provenanceService.generateTombstoneEvent(tombstoneAnnotation, currentAnnotation);
+    kafkaTemplate.send(TOPIC, mapper.writeValueAsString(event));
+  }
+
 }

--- a/src/main/java/eu/dissco/annotationprocessingservice/service/ProvenanceService.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/service/ProvenanceService.java
@@ -94,7 +94,7 @@ public class ProvenanceService {
   public CreateUpdateTombstoneEvent generateTombstoneEvent(Annotation tombstoneAnnotation,
       Annotation currentAnnotation) {
     var jsonPatch = createJsonPatch(tombstoneAnnotation, currentAnnotation);
-    return generateCreateUpdateTombStoneEvent(currentAnnotation, Type.ODS_TOMBSTONE, jsonPatch);
+    return generateCreateUpdateTombStoneEvent(tombstoneAnnotation, Type.ODS_TOMBSTONE, jsonPatch);
   }
 
   private ProvValue mapEntityToProvValue(Annotation annotation) {

--- a/src/main/java/eu/dissco/annotationprocessingservice/service/ProvenanceService.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/service/ProvenanceService.java
@@ -9,6 +9,7 @@ import eu.dissco.annotationprocessingservice.schema.Annotation;
 import eu.dissco.annotationprocessingservice.schema.CreateUpdateTombstoneEvent;
 import eu.dissco.annotationprocessingservice.schema.OdsChangeValue;
 import eu.dissco.annotationprocessingservice.schema.ProvActivity;
+import eu.dissco.annotationprocessingservice.schema.ProvActivity.Type;
 import eu.dissco.annotationprocessingservice.schema.ProvEntity;
 import eu.dissco.annotationprocessingservice.schema.ProvValue;
 import eu.dissco.annotationprocessingservice.schema.ProvWasAssociatedWith;
@@ -80,6 +81,12 @@ public class ProvenanceService {
         jsonPatch);
   }
 
+  public CreateUpdateTombstoneEvent generateTombstoneEvent(Annotation tombstoneAnnotation,
+      Annotation currentAnnotation) {
+    var jsonPatch = createJsonPatch(tombstoneAnnotation, currentAnnotation);
+    return generateCreateUpdateTombStoneEvent(currentAnnotation, Type.ODS_TOMBSTONE, jsonPatch);
+  }
+
   private ProvValue mapEntityToProvValue(Annotation annotation) {
     var provValue = new ProvValue();
     var node = mapper.convertValue(annotation, new TypeReference<Map<String, Object>>() {
@@ -91,7 +98,6 @@ public class ProvenanceService {
   }
 
   private JsonNode createJsonPatch(Annotation annotation, Annotation currentAnnotation) {
-    return JsonDiff.asJson(mapper.valueToTree(annotation),
-        mapper.valueToTree(currentAnnotation));
+    return JsonDiff.asJson(mapper.valueToTree(currentAnnotation), mapper.valueToTree(annotation));
   }
 }

--- a/src/main/java/eu/dissco/annotationprocessingservice/service/ProvenanceService.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/service/ProvenanceService.java
@@ -57,13 +57,23 @@ public class ProvenanceService {
                     .withId(annotation.getAsGenerator().getId())
                     .withProvHadRole(ProvHadRole.ODS_GENERATOR)))
             .withProvUsed(entityID)
-            .withRdfsComment("Annotation newly created"))
+            .withRdfsComment(getRdfsComment(activityType)))
         .withProvEntity(new ProvEntity()
             .withId(entityID)
             .withType(annotation.getType())
             .withProvValue(mapEntityToProvValue(annotation))
             .withProvWasGeneratedBy(activityID))
         .withOdsHasProvAgent(List.of(annotation.getDctermsCreator(), annotation.getAsGenerator()));
+  }
+
+  private static String getRdfsComment(ProvActivity.Type activityType) {
+    if (Type.ODS_CREATE.equals(activityType)){
+      return "Annotation newly created";
+    }
+    if (Type.ODS_UPDATE.equals(activityType)){
+      return "Annotation updated";
+    }
+    return "Annotation tombstoned";
   }
 
   private List<OdsChangeValue> mapJsonPatch(JsonNode jsonPatch) {

--- a/src/test/java/eu/dissco/annotationprocessingservice/TestUtils.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/TestUtils.java
@@ -9,25 +9,26 @@ import eu.dissco.annotationprocessingservice.configuration.DateDeserializer;
 import eu.dissco.annotationprocessingservice.configuration.DateSerializer;
 import eu.dissco.annotationprocessingservice.configuration.InstantDeserializer;
 import eu.dissco.annotationprocessingservice.configuration.InstantSerializer;
-import eu.dissco.annotationprocessingservice.domain.AutoAcceptedAnnotation;
-import eu.dissco.annotationprocessingservice.schema.Annotation.OdsMergingDecisionStatus;
-import eu.dissco.annotationprocessingservice.schema.AnnotationBatchMetadata;
-import eu.dissco.annotationprocessingservice.schema.AnnotationBody;
-import eu.dissco.annotationprocessingservice.schema.AnnotationProcessingEvent;
 import eu.dissco.annotationprocessingservice.domain.AnnotationTargetType;
-import eu.dissco.annotationprocessingservice.domain.ProcessedAnnotationBatch;
+import eu.dissco.annotationprocessingservice.domain.AutoAcceptedAnnotation;
 import eu.dissco.annotationprocessingservice.domain.HashedAnnotation;
 import eu.dissco.annotationprocessingservice.domain.HashedAnnotationRequest;
+import eu.dissco.annotationprocessingservice.domain.ProcessedAnnotationBatch;
 import eu.dissco.annotationprocessingservice.schema.Agent;
 import eu.dissco.annotationprocessingservice.schema.Agent.Type;
 import eu.dissco.annotationprocessingservice.schema.Annotation;
 import eu.dissco.annotationprocessingservice.schema.Annotation.OaMotivation;
+import eu.dissco.annotationprocessingservice.schema.Annotation.OdsMergingDecisionStatus;
 import eu.dissco.annotationprocessingservice.schema.Annotation.OdsStatus;
+import eu.dissco.annotationprocessingservice.schema.AnnotationBatchMetadata;
+import eu.dissco.annotationprocessingservice.schema.AnnotationBody;
+import eu.dissco.annotationprocessingservice.schema.AnnotationProcessingEvent;
 import eu.dissco.annotationprocessingservice.schema.AnnotationProcessingRequest;
 import eu.dissco.annotationprocessingservice.schema.AnnotationTarget;
 import eu.dissco.annotationprocessingservice.schema.OaHasSelector;
 import eu.dissco.annotationprocessingservice.schema.SchemaAggregateRating;
 import eu.dissco.annotationprocessingservice.schema.SearchParam;
+import eu.dissco.annotationprocessingservice.schema.TombstoneMetadata;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
@@ -44,6 +45,7 @@ public class TestUtils {
   public static final String ID_ALT = "https://hdl.handle.net/20.5000.1025/ZZZ-YYY-XXX";
   public static final String TARGET_ID = "20.5000.1025/QRS-123-ABC";
   public static final Instant CREATED = Instant.parse("2023-02-17T09:50:27.391Z");
+  public static final Instant UPDATED = Instant.parse("2024-02-17T09:50:27.391Z");
   public static final String CREATOR = "3fafe98f-1bf9-4927-b9c7-4ba070761a72";
   public static final String JOB_ID = "20.5000.1025/7YC-RGZ-LL1";
   public static final String PROCESSOR_HANDLE = "https://hdl.handle.net/anno-process-service-pid";
@@ -548,5 +550,26 @@ public class TestUtils {
   public static Map<String, UUID> givenBatchIdMap() {
     return Map.of(ID, BATCH_ID);
   }
+
+  public static Annotation givenTombstoneAnnotation(){
+    var original = givenAnnotationProcessed();
+    return givenAnnotationProcessed()
+        .withOdsVersion(original.getOdsVersion() + 1)
+        .withOdsStatus(OdsStatus.ODS_TOMBSTONE)
+        .withOdsTombstoneMetadata(givenTombstoneMetadata())
+        .withDctermsModified(Date.from(UPDATED))
+        .withOdsMergingDecisionStatus(OdsMergingDecisionStatus.ODS_REJECTED)
+        .withOdsMergingStateChangeDate(Date.from(UPDATED))
+        .withOdsMergingStateChangedBy(givenProcessingAgent());
+  }
+
+  public static TombstoneMetadata givenTombstoneMetadata(){
+    return new TombstoneMetadata()
+        .withType("ods:Tombstone")
+        .withOdsTombstoneDate(Date.from(UPDATED))
+        .withOdsTombstoneText("This annotation was archived")
+        .withOdsTombstonedByAgent(givenProcessingAgent());
+  }
+
 
 }

--- a/src/test/java/eu/dissco/annotationprocessingservice/TestUtils.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/TestUtils.java
@@ -557,10 +557,7 @@ public class TestUtils {
         .withOdsVersion(original.getOdsVersion() + 1)
         .withOdsStatus(OdsStatus.ODS_TOMBSTONE)
         .withOdsTombstoneMetadata(givenTombstoneMetadata())
-        .withDctermsModified(Date.from(UPDATED))
-        .withOdsMergingDecisionStatus(OdsMergingDecisionStatus.ODS_REJECTED)
-        .withOdsMergingStateChangeDate(Date.from(UPDATED))
-        .withOdsMergingStateChangedBy(givenProcessingAgent());
+        .withDctermsModified(Date.from(UPDATED));
   }
 
   public static TombstoneMetadata givenTombstoneMetadata(){

--- a/src/test/java/eu/dissco/annotationprocessingservice/controller/AnnotationControllerTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/controller/AnnotationControllerTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
+import eu.dissco.annotationprocessingservice.domain.AnnotationTombstoneWrapper;
 import eu.dissco.annotationprocessingservice.exception.ConflictException;
 import eu.dissco.annotationprocessingservice.exception.FailedProcessingException;
 import eu.dissco.annotationprocessingservice.service.ProcessingWebService;
@@ -96,12 +97,14 @@ class AnnotationControllerTest {
   }
 
   @Test
-  void testArchiveAnnotation() throws Exception {
+  void testTombstoneAnnotation() throws Exception {
     // Given
+    var tombstoneWrapper = new AnnotationTombstoneWrapper(givenAnnotationProcessed(),
+        givenProcessingAgent());
 
     // When
-    var result = controller.archiveAnnotation("20.5000.1025", "KZL-VC0-ZK2",
-        givenAnnotationProcessed(), givenProcessingAgent());
+    var result = controller.tombstoneAnnotation("20.5000.1025", "KZL-VC0-ZK2",
+        tombstoneWrapper);
 
     // Then
     assertThat(result.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
@@ -109,13 +112,15 @@ class AnnotationControllerTest {
   }
 
   @Test
-  void testArchiveAnnotationBadID() {
+  void testTombstoneAnnotationBadID() {
     // Given
+    var tombstoneWrapper = new AnnotationTombstoneWrapper(givenAnnotationProcessed(),
+        givenProcessingAgent());
 
     // When / Then
     assertThrowsExactly(FailedProcessingException.class,
-        () -> controller.archiveAnnotation("20.5000.1025", "INVALID-SUFFIX",
-            givenAnnotationProcessed(), givenProcessingAgent()));
+        () -> controller.tombstoneAnnotation("20.5000.1025", "INVALID-SUFFIX",
+            tombstoneWrapper));
 
   }
 

--- a/src/test/java/eu/dissco/annotationprocessingservice/controller/AnnotationControllerTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/controller/AnnotationControllerTest.java
@@ -1,16 +1,18 @@
 package eu.dissco.annotationprocessingservice.controller;
 
-import static eu.dissco.annotationprocessingservice.TestUtils.BARE_ID;
 import static eu.dissco.annotationprocessingservice.TestUtils.ID;
 import static eu.dissco.annotationprocessingservice.TestUtils.givenAnnotationEvent;
 import static eu.dissco.annotationprocessingservice.TestUtils.givenAnnotationProcessed;
 import static eu.dissco.annotationprocessingservice.TestUtils.givenAnnotationRequest;
+import static eu.dissco.annotationprocessingservice.TestUtils.givenProcessingAgent;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
 import eu.dissco.annotationprocessingservice.exception.ConflictException;
+import eu.dissco.annotationprocessingservice.exception.FailedProcessingException;
 import eu.dissco.annotationprocessingservice.service.ProcessingWebService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -98,11 +100,23 @@ class AnnotationControllerTest {
     // Given
 
     // When
-    var result = controller.archiveAnnotation("20.5000.1025", "KZL-VC0-ZK2");
+    var result = controller.archiveAnnotation("20.5000.1025", "KZL-VC0-ZK2",
+        givenAnnotationProcessed(), givenProcessingAgent());
 
     // Then
     assertThat(result.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
-    then(service).should().archiveAnnotation(BARE_ID);
+    then(service).should().archiveAnnotation(givenAnnotationProcessed(), givenProcessingAgent());
+  }
+
+  @Test
+  void testArchiveAnnotationBadID() {
+    // Given
+
+    // When / Then
+    assertThrowsExactly(FailedProcessingException.class,
+        () -> controller.archiveAnnotation("20.5000.1025", "INVALID-SUFFIX",
+            givenAnnotationProcessed(), givenProcessingAgent()));
+
   }
 
 }

--- a/src/test/java/eu/dissco/annotationprocessingservice/repository/AnnotationRepositoryIT.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/repository/AnnotationRepositoryIT.java
@@ -3,6 +3,7 @@ package eu.dissco.annotationprocessingservice.repository;
 import static eu.dissco.annotationprocessingservice.TestUtils.ANNOTATION_HASH;
 import static eu.dissco.annotationprocessingservice.TestUtils.ANNOTATION_HASH_2;
 import static eu.dissco.annotationprocessingservice.TestUtils.BARE_ID;
+import static eu.dissco.annotationprocessingservice.TestUtils.CREATED;
 import static eu.dissco.annotationprocessingservice.TestUtils.CREATOR;
 import static eu.dissco.annotationprocessingservice.TestUtils.HANDLE_PROXY;
 import static eu.dissco.annotationprocessingservice.TestUtils.ID;
@@ -163,7 +164,7 @@ class AnnotationRepositoryIT extends BaseRepositoryIT {
     repository.createAnnotationRecord(annotation);
 
     // When
-    repository.archiveAnnotation(givenAnnotationProcessed());
+    repository.archiveAnnotation(givenAnnotationProcessed(), CREATED);
 
     // Then
     var deletedTimestamp = context.select(ANNOTATION.TOMBSTONED_ON).from(ANNOTATION)

--- a/src/test/java/eu/dissco/annotationprocessingservice/repository/AnnotationRepositoryIT.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/repository/AnnotationRepositoryIT.java
@@ -8,6 +8,7 @@ import static eu.dissco.annotationprocessingservice.TestUtils.HANDLE_PROXY;
 import static eu.dissco.annotationprocessingservice.TestUtils.ID;
 import static eu.dissco.annotationprocessingservice.TestUtils.givenAnnotationProcessed;
 import static eu.dissco.annotationprocessingservice.TestUtils.givenHashedAnnotation;
+import static eu.dissco.annotationprocessingservice.TestUtils.givenTombstoneAnnotation;
 import static eu.dissco.annotationprocessingservice.database.jooq.Tables.ANNOTATION;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -15,7 +16,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.annotationprocessingservice.domain.HashedAnnotation;
 import eu.dissco.annotationprocessingservice.exception.DataBaseException;
-import eu.dissco.annotationprocessingservice.exception.FailedProcessingException;
 import eu.dissco.annotationprocessingservice.schema.Annotation;
 import eu.dissco.annotationprocessingservice.schema.Annotation.OaMotivation;
 import java.util.List;
@@ -163,7 +163,7 @@ class AnnotationRepositoryIT extends BaseRepositoryIT {
     repository.createAnnotationRecord(annotation);
 
     // When
-    repository.archiveAnnotation(givenAnnotationProcessed());
+    repository.archiveAnnotation(givenTombstoneAnnotation());
 
     // Then
     var deletedTimestamp = context.select(ANNOTATION.TOMBSTONED_ON).from(ANNOTATION)

--- a/src/test/java/eu/dissco/annotationprocessingservice/repository/AnnotationRepositoryIT.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/repository/AnnotationRepositoryIT.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.annotationprocessingservice.domain.HashedAnnotation;
 import eu.dissco.annotationprocessingservice.exception.DataBaseException;
+import eu.dissco.annotationprocessingservice.exception.FailedProcessingException;
 import eu.dissco.annotationprocessingservice.schema.Annotation;
 import eu.dissco.annotationprocessingservice.schema.Annotation.OaMotivation;
 import java.util.List;
@@ -156,13 +157,13 @@ class AnnotationRepositoryIT extends BaseRepositoryIT {
   }
 
   @Test
-  void testArchiveAnnotation() {
+  void testArchiveAnnotation() throws FailedProcessingException {
     // Given
     var annotation = givenAnnotationProcessed(BARE_ID);
     repository.createAnnotationRecord(annotation);
 
     // When
-    repository.archiveAnnotation(ID);
+    repository.archiveAnnotation(givenAnnotationProcessed());
 
     // Then
     var deletedTimestamp = context.select(ANNOTATION.TOMBSTONED_ON).from(ANNOTATION)

--- a/src/test/java/eu/dissco/annotationprocessingservice/repository/AnnotationRepositoryIT.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/repository/AnnotationRepositoryIT.java
@@ -3,7 +3,6 @@ package eu.dissco.annotationprocessingservice.repository;
 import static eu.dissco.annotationprocessingservice.TestUtils.ANNOTATION_HASH;
 import static eu.dissco.annotationprocessingservice.TestUtils.ANNOTATION_HASH_2;
 import static eu.dissco.annotationprocessingservice.TestUtils.BARE_ID;
-import static eu.dissco.annotationprocessingservice.TestUtils.CREATED;
 import static eu.dissco.annotationprocessingservice.TestUtils.CREATOR;
 import static eu.dissco.annotationprocessingservice.TestUtils.HANDLE_PROXY;
 import static eu.dissco.annotationprocessingservice.TestUtils.ID;
@@ -158,13 +157,13 @@ class AnnotationRepositoryIT extends BaseRepositoryIT {
   }
 
   @Test
-  void testArchiveAnnotation() throws FailedProcessingException {
+  void testArchiveAnnotation() {
     // Given
     var annotation = givenAnnotationProcessed(BARE_ID);
     repository.createAnnotationRecord(annotation);
 
     // When
-    repository.archiveAnnotation(givenAnnotationProcessed(), CREATED);
+    repository.archiveAnnotation(givenAnnotationProcessed());
 
     // Then
     var deletedTimestamp = context.select(ANNOTATION.TOMBSTONED_ON).from(ANNOTATION)

--- a/src/test/java/eu/dissco/annotationprocessingservice/service/FdoRecordServiceTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/service/FdoRecordServiceTest.java
@@ -100,7 +100,7 @@ class FdoRecordServiceTest {
         """);
 
     // When
-    var result = fdoRecordService.buildArchiveHandleRequest(ID);
+    var result = fdoRecordService.buildTombstoneHandleRequest(ID);
 
     // Then
     assertThat(result).isEqualTo(expected);

--- a/src/test/java/eu/dissco/annotationprocessingservice/service/KafkaPublisherServiceTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/service/KafkaPublisherServiceTest.java
@@ -4,6 +4,7 @@ package eu.dissco.annotationprocessingservice.service;
 import static eu.dissco.annotationprocessingservice.TestUtils.MAPPER;
 import static eu.dissco.annotationprocessingservice.TestUtils.givenAnnotationEventBatchEnabled;
 import static eu.dissco.annotationprocessingservice.TestUtils.givenAnnotationProcessed;
+import static eu.dissco.annotationprocessingservice.TestUtils.givenTombstoneAnnotation;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -31,6 +32,7 @@ class KafkaPublisherServiceTest {
   private ProvenanceService provenanceService;
 
   private KafkaPublisherService service;
+  private static final String TOPIC = "createUpdateDeleteTopic";
 
 
   @BeforeEach
@@ -47,7 +49,7 @@ class KafkaPublisherServiceTest {
     service.publishCreateEvent(givenAnnotationProcessed());
 
     // Then
-    then(kafkaTemplate).should().send(eq("createUpdateDeleteTopic"), anyString());
+    then(kafkaTemplate).should().send(eq(TOPIC), anyString());
   }
 
   @Test
@@ -59,7 +61,7 @@ class KafkaPublisherServiceTest {
         givenAnnotationProcessed());
 
     // Then
-    then(kafkaTemplate).should().send(eq("createUpdateDeleteTopic"), anyString());
+    then(kafkaTemplate).should().send(eq(TOPIC), anyString());
   }
 
   @Test
@@ -74,5 +76,18 @@ class KafkaPublisherServiceTest {
     // Then
     then(kafkaTemplate).should(times(1)).send("topic", eventMessage);
   }
+
+  @Test
+  void testPublishTombstoneAnnotation() throws JsonProcessingException {
+    // Given
+
+    // When
+    service.publishTombstoneEvent(givenTombstoneAnnotation(), givenAnnotationProcessed());
+
+    // Then
+    then(kafkaTemplate).should().send(eq(TOPIC), anyString());
+  }
+
+
 
 }

--- a/src/test/java/eu/dissco/annotationprocessingservice/service/ProcessingKafkaServiceTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/service/ProcessingKafkaServiceTest.java
@@ -811,15 +811,15 @@ class ProcessingKafkaServiceTest {
 
     // Then
     then(repository).should().archiveAnnotation(tombstonedAnnotation);
-    then(fdoRecordService).should().buildTombstoneHandleRequest(ID);
-    then(handleComponent).should().archiveHandle(any(), eq(ID));
+    then(fdoRecordService).should().buildTombstoneHandleRequest(BARE_ID);
+    then(handleComponent).should().archiveHandle(any(), eq(BARE_ID));
     then(masJobRecordService).shouldHaveNoInteractions();
   }
 
   @Test
   void testArchiveAnnotationHandleFailed() throws Exception {
     // Given
-    doThrow(PidCreationException.class).when(handleComponent).archiveHandle(any(), eq(ID));
+    doThrow(PidCreationException.class).when(handleComponent).archiveHandle(any(), eq(BARE_ID));
 
     // When
     assertThrows(FailedProcessingException.class,

--- a/src/test/java/eu/dissco/annotationprocessingservice/service/ProcessingKafkaServiceTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/service/ProcessingKafkaServiceTest.java
@@ -811,7 +811,7 @@ class ProcessingKafkaServiceTest {
 
     // Then
     then(repository).should().archiveAnnotation(tombstonedAnnotation);
-    then(fdoRecordService).should().buildArchiveHandleRequest(ID);
+    then(fdoRecordService).should().buildTombstoneHandleRequest(ID);
     then(handleComponent).should().archiveHandle(any(), eq(ID));
     then(masJobRecordService).shouldHaveNoInteractions();
   }

--- a/src/test/java/eu/dissco/annotationprocessingservice/service/ProcessingKafkaServiceTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/service/ProcessingKafkaServiceTest.java
@@ -810,7 +810,7 @@ class ProcessingKafkaServiceTest {
     service.archiveAnnotation(givenAnnotationProcessed(), givenProcessingAgent());
 
     // Then
-    then(repository).should().archiveAnnotation(tombstonedAnnotation, UPDATED);
+    then(repository).should().archiveAnnotation(tombstonedAnnotation);
     then(fdoRecordService).should().buildArchiveHandleRequest(ID);
     then(handleComponent).should().archiveHandle(any(), eq(ID));
     then(masJobRecordService).shouldHaveNoInteractions();

--- a/src/test/java/eu/dissco/annotationprocessingservice/service/ProcessingKafkaServiceTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/service/ProcessingKafkaServiceTest.java
@@ -810,7 +810,7 @@ class ProcessingKafkaServiceTest {
     service.archiveAnnotation(givenAnnotationProcessed(), givenProcessingAgent());
 
     // Then
-    then(repository).should().archiveAnnotation(tombstonedAnnotation);
+    then(repository).should().archiveAnnotation(tombstonedAnnotation, UPDATED);
     then(fdoRecordService).should().buildArchiveHandleRequest(ID);
     then(handleComponent).should().archiveHandle(any(), eq(ID));
     then(masJobRecordService).shouldHaveNoInteractions();

--- a/src/test/java/eu/dissco/annotationprocessingservice/service/ProvenanceServiceTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/service/ProvenanceServiceTest.java
@@ -87,7 +87,7 @@ class ProvenanceServiceTest {
     var event = service.generateTombstoneEvent(tombstoneAnnotation, annotation);
 
     // Then
-    assertThat(event.getOdsID()).isEqualTo(ID + "/" + 1);
+    assertThat(event.getOdsID()).isEqualTo(ID + "/" + 2);
     assertThat(event.getProvActivity().getOdsChangeValue()).isEqualTo(givenTombstoneChangeValue());
     assertThat(event.getProvEntity().getProvValue()).isNotNull();
     assertThat(event.getProvActivity().getRdfsComment()).isEqualTo("Annotation tombstoned");

--- a/src/test/java/eu/dissco/annotationprocessingservice/service/ProvenanceServiceTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/service/ProvenanceServiceTest.java
@@ -7,7 +7,6 @@ import static eu.dissco.annotationprocessingservice.TestUtils.UPDATED;
 import static eu.dissco.annotationprocessingservice.TestUtils.givenAnnotationProcessed;
 import static eu.dissco.annotationprocessingservice.TestUtils.givenCreator;
 import static eu.dissco.annotationprocessingservice.TestUtils.givenGenerator;
-import static eu.dissco.annotationprocessingservice.TestUtils.givenProcessingAgent;
 import static eu.dissco.annotationprocessingservice.TestUtils.givenTombstoneAnnotation;
 import static eu.dissco.annotationprocessingservice.TestUtils.givenTombstoneMetadata;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -15,7 +14,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.type.TypeReference;
 import eu.dissco.annotationprocessingservice.properties.ApplicationProperties;
 import eu.dissco.annotationprocessingservice.schema.Agent;
-import eu.dissco.annotationprocessingservice.schema.Annotation.OdsMergingDecisionStatus;
 import eu.dissco.annotationprocessingservice.schema.Annotation.OdsStatus;
 import eu.dissco.annotationprocessingservice.schema.OdsChangeValue;
 import java.util.List;
@@ -101,16 +99,11 @@ class ProvenanceServiceTest {
 
   private static List<OdsChangeValue> givenTombstoneChangeValue() {
     return List.of(
-        givenOdsChangeValue("add", "/ods:MergingStateChangedBy", givenProcessingAgent()),
         givenOdsChangeValue("add", "/ods:TombstoneMetadata", givenTombstoneMetadata()),
-        givenOdsChangeValue("add", "/ods:mergingStateChangeDate", UPDATED),
-        givenOdsChangeValue("add", "/ods:mergingDecisionStatus",
-            OdsMergingDecisionStatus.ODS_REJECTED),
         givenOdsChangeValue("replace", "/dcterms:modified", UPDATED),
         givenOdsChangeValue("replace", "/ods:version", 2),
         givenOdsChangeValue("replace", "/ods:status", OdsStatus.ODS_TOMBSTONE)
     );
-
   }
 
   private static OdsChangeValue givenOdsChangeValue(String op, String path, Object value) {

--- a/src/test/java/eu/dissco/annotationprocessingservice/service/ProvenanceServiceTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/service/ProvenanceServiceTest.java
@@ -3,13 +3,20 @@ package eu.dissco.annotationprocessingservice.service;
 import static eu.dissco.annotationprocessingservice.TestUtils.CREATOR;
 import static eu.dissco.annotationprocessingservice.TestUtils.ID;
 import static eu.dissco.annotationprocessingservice.TestUtils.MAPPER;
+import static eu.dissco.annotationprocessingservice.TestUtils.UPDATED;
 import static eu.dissco.annotationprocessingservice.TestUtils.givenAnnotationProcessed;
 import static eu.dissco.annotationprocessingservice.TestUtils.givenCreator;
 import static eu.dissco.annotationprocessingservice.TestUtils.givenGenerator;
+import static eu.dissco.annotationprocessingservice.TestUtils.givenProcessingAgent;
+import static eu.dissco.annotationprocessingservice.TestUtils.givenTombstoneAnnotation;
+import static eu.dissco.annotationprocessingservice.TestUtils.givenTombstoneMetadata;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import eu.dissco.annotationprocessingservice.properties.ApplicationProperties;
 import eu.dissco.annotationprocessingservice.schema.Agent;
+import eu.dissco.annotationprocessingservice.schema.Annotation.OdsMergingDecisionStatus;
+import eu.dissco.annotationprocessingservice.schema.Annotation.OdsStatus;
 import eu.dissco.annotationprocessingservice.schema.OdsChangeValue;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -56,12 +63,12 @@ class ProvenanceServiceTest {
   @Test
   void testGenerateUpdateEvent() {
     // Given
+    var currentAnnotation = givenAnnotationProcessed();
     var annotation = givenAnnotationProcessed();
-    var anotherAnnotation = givenAnnotationProcessed();
-    anotherAnnotation.setOaMotivatedBy("An updated motivation");
+    annotation.setOaMotivatedBy("An updated motivation");
 
     // When
-    var event = service.generateUpdateEvent(annotation, anotherAnnotation);
+    var event = service.generateUpdateEvent(annotation, currentAnnotation);
 
     // Then
     assertThat(event.getOdsID()).isEqualTo(ID + "/" + 1);
@@ -70,11 +77,48 @@ class ProvenanceServiceTest {
     assertThat(event.getOdsHasProvAgent()).isEqualTo(givenExpectedAgents());
   }
 
-  List<OdsChangeValue> givenChangeValue() {
-    return List.of(new OdsChangeValue()
-        .withAdditionalProperty("op", "add")
-        .withAdditionalProperty("path", "/oa:motivatedBy")
-        .withAdditionalProperty("value", "An updated motivation")
+  @Test
+  void testGenerateTombstoneEvent() {
+    // Given
+    var annotation = givenAnnotationProcessed();
+    var tombstoneAnnotation = givenTombstoneAnnotation();
+
+    // When
+    var event = service.generateTombstoneEvent(tombstoneAnnotation, annotation);
+
+    // Then
+    assertThat(event.getOdsID()).isEqualTo(ID + "/" + 1);
+    assertThat(event.getProvActivity().getOdsChangeValue()).isEqualTo(givenTombstoneChangeValue());
+    assertThat(event.getProvEntity().getProvValue()).isNotNull();
+    assertThat(event.getOdsHasProvAgent()).isEqualTo(givenExpectedAgents());
+  }
+
+  private static List<OdsChangeValue> givenChangeValue() {
+    return List.of(
+        givenOdsChangeValue("add", "/oa:motivatedBy", "An updated motivation")
     );
   }
+
+  private static List<OdsChangeValue> givenTombstoneChangeValue() {
+    return List.of(
+        givenOdsChangeValue("add", "/ods:MergingStateChangedBy", givenProcessingAgent()),
+        givenOdsChangeValue("add", "/ods:TombstoneMetadata", givenTombstoneMetadata()),
+        givenOdsChangeValue("add", "/ods:mergingStateChangeDate", UPDATED),
+        givenOdsChangeValue("add", "/ods:mergingDecisionStatus",
+            OdsMergingDecisionStatus.ODS_REJECTED),
+        givenOdsChangeValue("replace", "/dcterms:modified", UPDATED),
+        givenOdsChangeValue("replace", "/ods:version", 2),
+        givenOdsChangeValue("replace", "/ods:status", OdsStatus.ODS_TOMBSTONE)
+    );
+
+  }
+
+  private static OdsChangeValue givenOdsChangeValue(String op, String path, Object value) {
+    return new OdsChangeValue()
+        .withAdditionalProperty("op", op)
+        .withAdditionalProperty("path", path)
+        .withAdditionalProperty("value", MAPPER.convertValue(value, new TypeReference<>() {
+        }));
+  }
+
 }

--- a/src/test/java/eu/dissco/annotationprocessingservice/service/ProvenanceServiceTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/service/ProvenanceServiceTest.java
@@ -55,6 +55,7 @@ class ProvenanceServiceTest {
     assertThat(event.getOdsID()).isEqualTo(ID + "/" + 1);
     assertThat(event.getProvActivity().getOdsChangeValue()).isNull();
     assertThat(event.getProvEntity().getProvValue()).isNotNull();
+    assertThat(event.getProvActivity().getRdfsComment()).isEqualTo("Annotation newly created");
     assertThat(event.getOdsHasProvAgent()).isEqualTo(givenExpectedAgents());
   }
 
@@ -72,6 +73,7 @@ class ProvenanceServiceTest {
     assertThat(event.getOdsID()).isEqualTo(ID + "/" + 1);
     assertThat(event.getProvActivity().getOdsChangeValue()).isEqualTo(givenChangeValue());
     assertThat(event.getProvEntity().getProvValue()).isNotNull();
+    assertThat(event.getProvActivity().getRdfsComment()).isEqualTo("Annotation updated");
     assertThat(event.getOdsHasProvAgent()).isEqualTo(givenExpectedAgents());
   }
 
@@ -88,6 +90,7 @@ class ProvenanceServiceTest {
     assertThat(event.getOdsID()).isEqualTo(ID + "/" + 1);
     assertThat(event.getProvActivity().getOdsChangeValue()).isEqualTo(givenTombstoneChangeValue());
     assertThat(event.getProvEntity().getProvValue()).isNotNull();
+    assertThat(event.getProvActivity().getRdfsComment()).isEqualTo("Annotation tombstoned");
     assertThat(event.getOdsHasProvAgent()).isEqualTo(givenExpectedAgents());
   }
 


### PR DESCRIPTION
**Change to Endpoint**
- We now require the tombstoning agent and the resolved annotation in the request
- See https://github.com/DiSSCo/dissco-core-backend/pull/130 for changes there

**Tombstone Metadata**
- `ods:status` -> `ods:Tombstone`
- `ods:version` -> incremented
- `dcterms:modified` -> now
- `ods:mergingDecisionStatus` -> `ods:Rejected`
- `ods:mergingDecisionDateChange` -> now
- `ods:mergingStateChangedBy` -> tombstoning agent
- `ods:tombstoningMetadata` -> 
         - `ods:tombstoneDate` -> now
         - `ods:tombstoneText` -> "This annotation was archived"
         - `ods:tombstonedByAgent` -> tombstoning agent
         - `ods:hasRelatedPid` -> `null`. We already have the target PID in the Target Object

**Exception Handling (Or lack thereof)**
- updating db can throw FailedProcessingException
- kafka service can throw JsonProcessingException
- We don't have any rollback (roll-forward?) functionality for tombstone operations. handle api can't restore PID to an un-tombstoned version. if we really want to restore a tombstoned object on a failure, we could add that feature and then re-index the annotation in elastic on failure to tombstone, but i think the best thing would be to manually fix the issue

**Delete Event**
- Sends tombstone event to prov service

**JsonPatch fix**
- JsonDiff was the wrong way around. it was calculating changes as if the previous version was the new version, so all information was flipped (i.e. added terms were marked as removed, values were the previous version instead of the new version, etc)

**Other changes**
- postfix -> suffix
- remove check to see if annotation exists; the back end already checked this, it's a redundant db call