### PR TITLE
Split kafka auto into separate service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.3.5</version>
+    <version>3.4.0</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>eu.dissco.core</groupId>
@@ -21,6 +21,7 @@
     <json-path.version>2.9.0</json-path.version>
     <mockito-inline.version>5.2.0</mockito-inline.version>
     <testcontainers.version>1.20.1</testcontainers.version>
+    <ok-http.version>4.12.0</ok-http.version>
     <sonar.organization>dissco</sonar.organization>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <json-schema-validator.version>1.5.1</json-schema-validator.version>
@@ -172,11 +173,13 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
+      <version>${ok-http.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
+      <version>${ok-http.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -283,6 +286,7 @@
           <includeConstructors>true</includeConstructors>
           <includeDynamicBuilders>true</includeDynamicBuilders>
           <includeAdditionalProperties>true</includeAdditionalProperties>
+          <inclusionLevel>NON_EMPTY</inclusionLevel>
         </configuration>
         <executions>
           <execution>

--- a/src/main/java/eu/dissco/annotationprocessingservice/Profiles.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/Profiles.java
@@ -2,7 +2,8 @@ package eu.dissco.annotationprocessingservice;
 
 public class Profiles {
 
-  public static final String KAFKA = "kafka";
+  public static final String KAFKA_MAS = "kafka-mas";
+  public static final String KAFKA_AUTO = "kafka-auto";
   public static final String WEB = "web";
 
   private Profiles() {

--- a/src/main/java/eu/dissco/annotationprocessingservice/configuration/KafkaConsumerConfiguration.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/configuration/KafkaConsumerConfiguration.java
@@ -14,7 +14,7 @@ import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 
-@Profile(Profiles.KAFKA)
+@Profile({Profiles.KAFKA_MAS, Profiles.KAFKA_AUTO})
 @Configuration
 @AllArgsConstructor
 public class KafkaConsumerConfiguration {

--- a/src/main/java/eu/dissco/annotationprocessingservice/service/KafkaAutoConsumerService.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/service/KafkaAutoConsumerService.java
@@ -7,7 +7,6 @@ import eu.dissco.annotationprocessingservice.exception.DataBaseException;
 import eu.dissco.annotationprocessingservice.exception.FailedProcessingException;
 import java.io.IOException;
 import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.messaging.handler.annotation.Payload;

--- a/src/main/java/eu/dissco/annotationprocessingservice/service/KafkaAutoConsumerService.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/service/KafkaAutoConsumerService.java
@@ -3,12 +3,8 @@ package eu.dissco.annotationprocessingservice.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.annotationprocessingservice.Profiles;
 import eu.dissco.annotationprocessingservice.domain.AutoAcceptedAnnotation;
-import eu.dissco.annotationprocessingservice.exception.AnnotationValidationException;
-import eu.dissco.annotationprocessingservice.exception.BatchingException;
-import eu.dissco.annotationprocessingservice.exception.ConflictException;
 import eu.dissco.annotationprocessingservice.exception.DataBaseException;
 import eu.dissco.annotationprocessingservice.exception.FailedProcessingException;
-import eu.dissco.annotationprocessingservice.schema.AnnotationProcessingEvent;
 import java.io.IOException;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,23 +14,15 @@ import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Service;
 
 @Service
-@Slf4j
-@Profile(Profiles.KAFKA)
+@Profile(Profiles.KAFKA_AUTO)
 @AllArgsConstructor
-public class KafkaConsumerService {
+public class KafkaAutoConsumerService {
 
   private final ObjectMapper mapper;
-  private final ProcessingKafkaService service;
   private final ProcessingAutoAcceptedService autoAcceptedService;
 
-  @KafkaListener(topics = "${kafka.consumer.topic}")
-  public void getMessages(@Payload String message)
-      throws IOException, DataBaseException, FailedProcessingException, AnnotationValidationException, ConflictException, BatchingException {
-    var event = mapper.readValue(message, AnnotationProcessingEvent.class);
-    service.handleMessage(event);
-  }
 
-  @KafkaListener(topics = "${kafka.consumer.topic.auto-accepted}")
+  @KafkaListener(topics = "${kafka.consumer.topic}")
   public void getAutoAcceptedMessages(@Payload String message)
       throws IOException, DataBaseException, FailedProcessingException {
     var event = mapper.readValue(message, AutoAcceptedAnnotation.class);

--- a/src/main/java/eu/dissco/annotationprocessingservice/service/KafkaMasConsumerService.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/service/KafkaMasConsumerService.java
@@ -1,0 +1,33 @@
+package eu.dissco.annotationprocessingservice.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import eu.dissco.annotationprocessingservice.Profiles;
+import eu.dissco.annotationprocessingservice.exception.AnnotationValidationException;
+import eu.dissco.annotationprocessingservice.exception.BatchingException;
+import eu.dissco.annotationprocessingservice.exception.ConflictException;
+import eu.dissco.annotationprocessingservice.exception.DataBaseException;
+import eu.dissco.annotationprocessingservice.exception.FailedProcessingException;
+import eu.dissco.annotationprocessingservice.schema.AnnotationProcessingEvent;
+import java.io.IOException;
+import lombok.AllArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Service;
+
+@Service
+@Profile(Profiles.KAFKA_MAS)
+@AllArgsConstructor
+public class KafkaMasConsumerService {
+
+  private final ObjectMapper mapper;
+  private final ProcessingKafkaService service;
+
+  @KafkaListener(topics = "${kafka.consumer.topic}")
+  public void getMessages(@Payload String message)
+      throws IOException, DataBaseException, FailedProcessingException, AnnotationValidationException, ConflictException, BatchingException {
+    var event = mapper.readValue(message, AnnotationProcessingEvent.class);
+    service.handleMessage(event);
+  }
+
+}

--- a/src/main/java/eu/dissco/annotationprocessingservice/service/MasJobRecordService.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/service/MasJobRecordService.java
@@ -24,11 +24,11 @@ public class MasJobRecordService {
   private final ObjectMapper mapper;
 
   public void verifyMasJobId(AnnotationProcessingEvent event) throws FailedProcessingException {
-    if (environment.matchesProfiles(Profiles.KAFKA) && event.getJobId() == null) {
+    if (environment.matchesProfiles(Profiles.KAFKA_MAS, Profiles.KAFKA_AUTO) && event.getJobId() == null) {
       log.error("Missing MAS Job ID for event {}", event);
       throw new FailedProcessingException();
     }
-    if (!environment.matchesProfiles(Profiles.KAFKA)) {
+    if (!environment.matchesProfiles(Profiles.KAFKA_MAS, Profiles.KAFKA_AUTO)) {
       throw new UnsupportedOperationException();
     }
   }

--- a/src/main/java/eu/dissco/annotationprocessingservice/service/MasJobRecordService.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/service/MasJobRecordService.java
@@ -24,7 +24,8 @@ public class MasJobRecordService {
   private final ObjectMapper mapper;
 
   public void verifyMasJobId(AnnotationProcessingEvent event) throws FailedProcessingException {
-    if (environment.matchesProfiles(Profiles.KAFKA_MAS, Profiles.KAFKA_AUTO) && event.getJobId() == null) {
+    if (environment.matchesProfiles(Profiles.KAFKA_MAS, Profiles.KAFKA_AUTO)
+        && event.getJobId() == null) {
       log.error("Missing MAS Job ID for event {}", event);
       throw new FailedProcessingException();
     }

--- a/src/main/java/eu/dissco/annotationprocessingservice/service/ProcessingAutoAcceptedService.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/service/ProcessingAutoAcceptedService.java
@@ -22,7 +22,7 @@ import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
-@Profile(Profiles.KAFKA)
+@Profile(Profiles.KAFKA_AUTO)
 public class ProcessingAutoAcceptedService extends AbstractProcessingService {
 
   public ProcessingAutoAcceptedService(

--- a/src/main/java/eu/dissco/annotationprocessingservice/service/ProcessingKafkaService.java
+++ b/src/main/java/eu/dissco/annotationprocessingservice/service/ProcessingKafkaService.java
@@ -46,7 +46,7 @@ import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
-@Profile(Profiles.KAFKA)
+@Profile(Profiles.KAFKA_MAS)
 public class ProcessingKafkaService extends AbstractProcessingService {
 
   private final AnnotationHasher annotationHasher;

--- a/src/test/java/eu/dissco/annotationprocessingservice/service/AnnotationBatchRecordServiceTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/service/AnnotationBatchRecordServiceTest.java
@@ -39,14 +39,12 @@ class AnnotationBatchRecordServiceTest {
   private AnnotationBatchRecordRepository repository;
   private AnnotationBatchRecordService service;
   private MockedStatic<Clock> mockedClock;
-
+  private MockedStatic<Instant> mockedStatic;
 
   @BeforeEach
   void setup() {
     service = new AnnotationBatchRecordService(repository);
   }
-
-  private MockedStatic<Instant> mockedStatic;
 
   @Test
   void testMintBatchIdsBatchingRequested() {

--- a/src/test/java/eu/dissco/annotationprocessingservice/service/FdoRecordServiceTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/service/FdoRecordServiceTest.java
@@ -52,7 +52,7 @@ class FdoRecordServiceTest {
   void testBuildPostRequestBatch() throws Exception {
     // Given
     var expected = givenPostRequest().get(0);
-    ((ObjectNode)expected.get("data").get("attributes"))
+    ((ObjectNode) expected.get("data").get("attributes"))
         .put("annotationHash", ANNOTATION_HASH.toString());
 
     // When
@@ -75,7 +75,7 @@ class FdoRecordServiceTest {
   void testPatchRequestBatch() throws Exception {
     // Given
     var expected = givenPatchRequest().get(0);
-    ((ObjectNode)expected.get("data").get("attributes"))
+    ((ObjectNode) expected.get("data").get("attributes"))
         .put("annotationHash", ANNOTATION_HASH.toString());
     // When
     var result = fdoRecordService.buildPatchRollbackHandleRequest(List.of(givenHashedAnnotation()));

--- a/src/test/java/eu/dissco/annotationprocessingservice/service/KafkaAutoConsumerServiceTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/service/KafkaAutoConsumerServiceTest.java
@@ -1,0 +1,43 @@
+package eu.dissco.annotationprocessingservice.service;
+
+import static eu.dissco.annotationprocessingservice.TestUtils.MAPPER;
+import static eu.dissco.annotationprocessingservice.TestUtils.givenAutoAcceptedRequest;
+import static org.mockito.BDDMockito.then;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class KafkaAutoConsumerServiceTest {
+
+  @Mock
+  private ProcessingAutoAcceptedService autoAcceptedService;
+
+  private KafkaAutoConsumerService service;
+
+  @BeforeEach
+  void setup() {
+    service = new KafkaAutoConsumerService(MAPPER, autoAcceptedService);
+  }
+
+  @Test
+  void testGetAutoAcceptedMessages() throws Exception {
+    // Given
+    var message = givenAutoAcceptedMessage();
+
+    // When
+    service.getAutoAcceptedMessages(message);
+
+    // Then
+    then(autoAcceptedService).should().handleMessage(givenAutoAcceptedRequest());
+  }
+
+  private String givenAutoAcceptedMessage() throws JsonProcessingException {
+    return MAPPER.writeValueAsString(givenAutoAcceptedRequest());
+  }
+
+}

--- a/src/test/java/eu/dissco/annotationprocessingservice/service/KafkaMasConsumerServiceTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/service/KafkaMasConsumerServiceTest.java
@@ -4,10 +4,8 @@ import static eu.dissco.annotationprocessingservice.TestUtils.JOB_ID;
 import static eu.dissco.annotationprocessingservice.TestUtils.MAPPER;
 import static eu.dissco.annotationprocessingservice.TestUtils.givenAnnotationEvent;
 import static eu.dissco.annotationprocessingservice.TestUtils.givenAnnotationRequest;
-import static eu.dissco.annotationprocessingservice.TestUtils.givenAutoAcceptedRequest;
 import static org.mockito.BDDMockito.then;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,18 +14,15 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class KafkaConsumerServiceTest {
+class KafkaMasConsumerServiceTest {
 
   @Mock
   private ProcessingKafkaService processingKafkaService;
-  @Mock
-  private ProcessingAutoAcceptedService autoAcceptedService;
-
-  private KafkaConsumerService service;
+  private KafkaMasConsumerService service;
 
   @BeforeEach
   void setup() {
-    service = new KafkaConsumerService(MAPPER, processingKafkaService, autoAcceptedService);
+    service = new KafkaMasConsumerService(MAPPER, processingKafkaService);
   }
 
   @Test
@@ -40,22 +35,6 @@ class KafkaConsumerServiceTest {
 
     // Then
     then(processingKafkaService).should().handleMessage(givenAnnotationEvent());
-  }
-
-  @Test
-  void testGetAutoAcceptedMessages() throws Exception {
-    // Given
-    var message = givenAutoAcceptedMessage();
-
-    // When
-    service.getAutoAcceptedMessages(message);
-
-    // Then
-    then(autoAcceptedService).should().handleMessage(givenAutoAcceptedRequest());
-  }
-
-  private String givenAutoAcceptedMessage() throws JsonProcessingException {
-    return MAPPER.writeValueAsString(givenAutoAcceptedRequest());
   }
 
   private String givenMessage() throws Exception {

--- a/src/test/java/eu/dissco/annotationprocessingservice/service/KafkaPublisherServiceTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/service/KafkaPublisherServiceTest.java
@@ -24,16 +24,14 @@ import org.springframework.kafka.core.KafkaTemplate;
 @ExtendWith(MockitoExtension.class)
 class KafkaPublisherServiceTest {
 
+  private static final String TOPIC = "createUpdateDeleteTopic";
   @Mock
   private KafkaTemplate<String, String> kafkaTemplate;
   @Mock
   private KafkaConsumerProperties consumerProperties;
   @Mock
   private ProvenanceService provenanceService;
-
   private KafkaPublisherService service;
-  private static final String TOPIC = "createUpdateDeleteTopic";
-
 
   @BeforeEach
   void setup() {
@@ -87,7 +85,6 @@ class KafkaPublisherServiceTest {
     // Then
     then(kafkaTemplate).should().send(eq(TOPIC), anyString());
   }
-
 
 
 }

--- a/src/test/java/eu/dissco/annotationprocessingservice/service/MasJobRecordServiceTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/service/MasJobRecordServiceTest.java
@@ -45,7 +45,7 @@ class MasJobRecordServiceTest {
   @Test
   void testVerifyMasJobIdKafka() {
     // Given
-    given(environment.matchesProfiles(Profiles.KAFKA)).willReturn(true);
+    given(environment.matchesProfiles(Profiles.KAFKA_MAS, Profiles.KAFKA_AUTO)).willReturn(true);
 
     // When
     assertDoesNotThrow(() -> service.verifyMasJobId(givenAnnotationEvent()));
@@ -64,7 +64,7 @@ class MasJobRecordServiceTest {
   void testVerifyMasJobIdWeb() {
     // Given
     var annotationEvent = givenAnnotationEvent();
-    given(environment.matchesProfiles(Profiles.KAFKA)).willReturn(false);
+    given(environment.matchesProfiles(Profiles.KAFKA_MAS, Profiles.KAFKA_AUTO)).willReturn(false);
 
     // When
     assertThrows(UnsupportedOperationException.class, () -> service.verifyMasJobId(annotationEvent));
@@ -73,7 +73,7 @@ class MasJobRecordServiceTest {
   @Test
   void testVerifyMasJobIdKafkaFails() {
     // Given
-    given(environment.matchesProfiles(Profiles.KAFKA)).willReturn(true);
+    given(environment.matchesProfiles(Profiles.KAFKA_MAS, Profiles.KAFKA_AUTO)).willReturn(true);
 
     // When
     assertThrows(FailedProcessingException.class,

--- a/src/test/java/eu/dissco/annotationprocessingservice/service/MasJobRecordServiceTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/service/MasJobRecordServiceTest.java
@@ -52,7 +52,7 @@ class MasJobRecordServiceTest {
   }
 
   @Test
-  void testMarkEmptyMasJobRecordAsComplete(){
+  void testMarkEmptyMasJobRecordAsComplete() {
     // When
     service.markEmptyMasJobRecordAsComplete(JOB_ID, false);
 
@@ -67,7 +67,8 @@ class MasJobRecordServiceTest {
     given(environment.matchesProfiles(Profiles.KAFKA_MAS, Profiles.KAFKA_AUTO)).willReturn(false);
 
     // When
-    assertThrows(UnsupportedOperationException.class, () -> service.verifyMasJobId(annotationEvent));
+    assertThrows(UnsupportedOperationException.class,
+        () -> service.verifyMasJobId(annotationEvent));
   }
 
   @Test
@@ -77,8 +78,9 @@ class MasJobRecordServiceTest {
 
     // When
     assertThrows(FailedProcessingException.class,
-        () -> service.verifyMasJobId(new AnnotationProcessingEvent(null, List.of(givenAnnotationRequest()), null,
-            null)));
+        () -> service.verifyMasJobId(
+            new AnnotationProcessingEvent(null, List.of(givenAnnotationRequest()), null,
+                null)));
   }
 
   @Test
@@ -103,7 +105,7 @@ class MasJobRecordServiceTest {
   }
 
   @Test
-  void testMarkMasJobRecordAsCompletedBatchResult(){
+  void testMarkMasJobRecordAsCompletedBatchResult() {
     // Given
     // When
     service.markMasJobRecordAsComplete(JOB_ID, List.of(ID_ALT), true);
@@ -113,7 +115,7 @@ class MasJobRecordServiceTest {
   }
 
   @Test
-  void testMarkMasJobRecordAsFailedBatchResult(){
+  void testMarkMasJobRecordAsFailedBatchResult() {
     // When
     service.markMasJobRecordAsFailed(JOB_ID, true);
 
@@ -122,7 +124,7 @@ class MasJobRecordServiceTest {
   }
 
   @Test
-  void testMarkEmptyMasJobRecordAsCompletedBatchResult(){
+  void testMarkEmptyMasJobRecordAsCompletedBatchResult() {
     // When
     service.markEmptyMasJobRecordAsComplete(JOB_ID, true);
 
@@ -131,9 +133,9 @@ class MasJobRecordServiceTest {
   }
 
   @Test
-  void testGetMasJobRecord(){
+  void testGetMasJobRecord() {
     // Given
-    var expected = new MasJobRecord(JOB_ID,true, null);
+    var expected = new MasJobRecord(JOB_ID, true, null);
     given(repository.getMasJobRecord(JOB_ID)).willReturn(expected);
 
     // When

--- a/src/test/java/eu/dissco/annotationprocessingservice/service/ProcessingAutoAcceptedServiceTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/service/ProcessingAutoAcceptedServiceTest.java
@@ -75,7 +75,8 @@ class ProcessingAutoAcceptedServiceTest {
   void setup() {
     service = new ProcessingAutoAcceptedService(repository, elasticRepository,
         kafkaPublisherService, fdoRecordService, handleComponent, applicationProperties,
-        schemaValidator, masJobRecordService, batchAnnotationService, annotationBatchRecordService, fdoProperties);
+        schemaValidator, masJobRecordService, batchAnnotationService, annotationBatchRecordService,
+        fdoProperties);
     mockedStatic = mockStatic(Instant.class);
     mockedStatic.when(Instant::now).thenReturn(instant);
     mockedClock.when(Clock::systemUTC).thenReturn(clock);

--- a/src/test/java/eu/dissco/annotationprocessingservice/service/ProcessingWebServiceTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/service/ProcessingWebServiceTest.java
@@ -88,7 +88,8 @@ class ProcessingWebServiceTest {
   void setup() {
     service = new ProcessingWebService(repository, elasticRepository,
         kafkaPublisherService, fdoRecordService, handleComponent, applicationProperties,
-        schemaValidator, masJobRecordService, batchAnnotationService, annotationBatchRecordService, fdoProperties);
+        schemaValidator, masJobRecordService, batchAnnotationService, annotationBatchRecordService,
+        fdoProperties);
     mockedStatic = mockStatic(Instant.class);
     mockedStatic.when(Instant::now).thenReturn(instant);
     mockedClock.when(Clock::systemUTC).thenReturn(clock);
@@ -159,7 +160,8 @@ class ProcessingWebServiceTest {
     var processedAnnotation = givenAnnotationProcessedWebBatch();
     var requestEvent = new AnnotationProcessingEvent(null, List.of(givenAnnotationRequest()),
         List.of(givenAnnotationBatchMetadataTwoParam()), null);
-    var processedEvent = new ProcessedAnnotationBatch(List.of(givenAnnotationProcessedWebBatch()), null,
+    var processedEvent = new ProcessedAnnotationBatch(List.of(givenAnnotationProcessedWebBatch()),
+        null,
         List.of(givenAnnotationBatchMetadataTwoParam()), null);
 
     // When

--- a/src/test/java/eu/dissco/annotationprocessingservice/service/ProvenanceServiceTest.java
+++ b/src/test/java/eu/dissco/annotationprocessingservice/service/ProvenanceServiceTest.java
@@ -38,6 +38,29 @@ class ProvenanceServiceTest {
     );
   }
 
+  private static List<OdsChangeValue> givenChangeValue() {
+    return List.of(
+        givenOdsChangeValue("add", "/oa:motivatedBy", "An updated motivation")
+    );
+  }
+
+  private static List<OdsChangeValue> givenTombstoneChangeValue() {
+    return List.of(
+        givenOdsChangeValue("add", "/ods:hasTombstoneMetadata", givenTombstoneMetadata()),
+        givenOdsChangeValue("replace", "/dcterms:modified", UPDATED),
+        givenOdsChangeValue("replace", "/ods:version", 2),
+        givenOdsChangeValue("replace", "/ods:status", OdsStatus.TOMBSTONE)
+    );
+  }
+
+  private static OdsChangeValue givenOdsChangeValue(String op, String path, Object value) {
+    return new OdsChangeValue()
+        .withAdditionalProperty("op", op)
+        .withAdditionalProperty("path", path)
+        .withAdditionalProperty("value", MAPPER.convertValue(value, new TypeReference<>() {
+        }));
+  }
+
   @BeforeEach
   void setup() {
     this.service = new ProvenanceService(MAPPER, properties);
@@ -92,29 +115,6 @@ class ProvenanceServiceTest {
     assertThat(event.getProvEntity().getProvValue()).isNotNull();
     assertThat(event.getProvActivity().getRdfsComment()).isEqualTo("Annotation tombstoned");
     assertThat(event.getOdsHasAgents()).isEqualTo(givenExpectedAgents());
-  }
-
-  private static List<OdsChangeValue> givenChangeValue() {
-    return List.of(
-        givenOdsChangeValue("add", "/oa:motivatedBy", "An updated motivation")
-    );
-  }
-
-  private static List<OdsChangeValue> givenTombstoneChangeValue() {
-    return List.of(
-        givenOdsChangeValue("add", "/ods:hasTombstoneMetadata", givenTombstoneMetadata()),
-        givenOdsChangeValue("replace", "/dcterms:modified", UPDATED),
-        givenOdsChangeValue("replace", "/ods:version", 2),
-        givenOdsChangeValue("replace", "/ods:status", OdsStatus.TOMBSTONE)
-    );
-  }
-
-  private static OdsChangeValue givenOdsChangeValue(String op, String path, Object value) {
-    return new OdsChangeValue()
-        .withAdditionalProperty("op", op)
-        .withAdditionalProperty("path", path)
-        .withAdditionalProperty("value", MAPPER.convertValue(value, new TypeReference<>() {
-        }));
   }
 
 }


### PR DESCRIPTION
- Split Kafka into two profiles, one for MAS and one for Auto(-accepted annotations)
- Couple formatting things

Has implications for the deployment, have a PR for that as well